### PR TITLE
Feature/#37 - Rename master to official

### DIFF
--- a/docs/manuals/core/concepts/cycle.md
+++ b/docs/manuals/core/concepts/cycle.md
@@ -11,28 +11,25 @@ a scenario in production. In Taipy, a _cycle_ duration depends on the
 - `Frequency.YEARLY`
 
 Each recurrent scenario is attached to a _cycle_. In other words, each _cycle_ contains multiple scenarios. At the end
-of a cycle (start date + duration), only one of the scenarios can be applied in production. This scenario is
-called _master scenario_. There is only one _master scenario_ per cycle.
+of a cycle (start date + duration), only one of the scenarios can be applied in production. This scenario is called _official scenario_. There is only one _official scenario_ per cycle.
 
 !!! example
 
     The user must publish production orders every month. Each month is
     modeled as a cycle in Taipy, and each cycle contains one or multiple scenarios.
 
-    Depending on the simulation we ran, we may have one unique scenario (a master one) for the January cycle and two
+    Depending on the simulation we ran, we may have one unique scenario (the official one) for the January cycle and two
     scenarios for the February cycle (one with the low capacity assumption and one with the high capacity assumption).
     As a user of the application, I can decide to apply the low capacity scenario in production for February.
-    For that, I promote my low capacity scenario as master for the February cycle.
+    For that, I promote my low capacity scenario as official for the February cycle.
 
     The tree of entities resulting from the various scenarios created is represented on the following picture.
     ![cycles](pic/cycles_grey.svg){ width="250" }
-
 
 The attributes of a scenario (the set of pipelines, the cycle, ... ) are populated based on the scenario configuration
 ([`ScenarioConfig`](../../../reference/#taipy.core.config.scenario_config.ScenarioConfig)) that
 must be provided when instantiating a new scenario. (Please refer to the
 [`configuration details`](../config/scenario-config.md) documentation for more
 details on configuration).
-
 
 [:material-arrow-right: Next section introduces the Scope concept.](scope.md)

--- a/docs/manuals/core/features/scenario-cycle-mgt.md
+++ b/docs/manuals/core/features/scenario-cycle-mgt.md
@@ -6,7 +6,7 @@ A scenario also holds various properties accessible as an attribute of the scena
 
 -   `scenario.config_name` is the name of the scenario configuration.
 -   `scenario.creation_date` corresponds to the date-time provided at the creation.
--   `scenario.is_master` equals True if it is a master scenario. False otherwise.
+-   `scenario.is_official` equals True if it is an official scenario. False otherwise.
 -   `scenario.subscribers` is the list of callbacks representing the subscribers.
 -   `scenario.properties` is the complete dictionary of the scenario properties. It includes a copy of
     the properties of the scenario configuration, in addition to the properties provided at the creation and at runtime.
@@ -30,8 +30,8 @@ A scenario also holds various properties accessible as an attribute of the scena
         scenario.config_name
         # The creation date is the date-time provided at the creation. It equals datetime(2022, 1, 1)
         scenario.creation_date
-        # Is_master property equals `True` since it is the only scenario of the cycle.
-        scenario.is_master
+        # The is_official property equals `True` since it is the only scenario of the cycle.
+        scenario.is_official
         # There was no subscription, so subscribers is an empty list
         scenario.subscribers # []
         # The properties dictionary equals {"name": "Scenario for January"}. It contains all the properties,
@@ -73,19 +73,19 @@ All the scenarios can be retrieved using the method [`taipy.get_scenarios`](../.
 This method returns the list of all existing scenarios. If a cycle is given as parameter, the list contains all the
 existing scenarios of the cycle.
 
-# Get master scenarios
+# Get official scenarios
 
-[`taipy.get_master`](../../../reference/#taipy.core.taipy.get_master) method returns the master scenario of the cycle
+[`taipy.get_official`](../../../reference/#taipy.core.taipy.get_official) method returns the official scenario of the cycle
 given as parameter.
 
-[`taipy.get_all_masters`](../../../reference/#taipy.core.taipy.get_all_masters) returns the master scenarios for
+[`taipy.get_all_official`](../../../reference/#taipy.core.taipy.get_all_official) returns the official scenarios for
 all the existing cycles.
 
-# Promote a scenario as master
+# Promote a scenario as official
 
-To set a scenario as master, the [`taipy.set_master`](../../../reference/#taipy.core.taipy.set_master) method must
-be used. It promotes the scenario given as parameter to the master scenario of its cycle. If the cycle already
-had a master scenario it will be demoted, and it will no longer be master for the cycle.
+To set a scenario as official, the [`taipy.set_official`](../../../reference/#taipy.core.taipy.set_official) method must
+be used. It promotes the scenario given as parameter to the official scenario of its cycle. If the cycle already
+had an official scenario it will be demoted, and it will no longer be official for the cycle.
 
 # Delete a scenario
 


### PR DESCRIPTION
Note: I rename the get_all_masters to get_all_official instead of get_all_officials. Let me know what you think about this, since the term "officials" does not sound correct.