### PR TITLE
Replace data scientist by Python developer

### DIFF
--- a/docs/manuals/about.md
+++ b/docs/manuals/about.md
@@ -11,7 +11,7 @@ in order to see a step-by-step example of a complete Taipy application.
 ## Taipy Core - `taipy.core`
 
 The `taipy.core^` package is a Python library made to build powerful and customized data-driven back-end applications.
-It provides the necessary tools to help data scientists transform their algorithms into a complete
+It provides the necessary tools to help Python developer transform their algorithms into a complete
 back-end application.
 
 Taipy Core brings algorithm management to another level: algorithms are now connected to the end-user through

--- a/docs/manuals/core/concepts/index.md
+++ b/docs/manuals/core/concepts/index.md
@@ -1,6 +1,6 @@
 # Taipy's Core concepts
 
-Taipy Core is an application builder designed to help data scientists turn their algorithms into an interactive
+Taipy Core is an application builder designed to help Python developer turn their algorithms into an interactive
 production-ready data-driven application. Taipy Core provides the necessary concepts for modeling, executing, and
 monitoring algorithms/pipelines.
 

--- a/docs/manuals/core/config/data-node-config.md
+++ b/docs/manuals/core/config/data-node-config.md
@@ -60,17 +60,17 @@ data nodes instantiated from this config.
 # Storage type
 
 Taipy proposes various predefined _data nodes_ corresponding to the most popular
-_storage types_. Thanks to predefined _data nodes_, the data scientist developer does not need
+_storage types_. Thanks to predefined _data nodes_, the Python developer does not need
 to spend much time configuring the _storage types_ or the
 _query system_. Most of the time, a predefined _data node_ corresponding to a basic and standard use case satisfies
 the user's needs like pickle file, csv file, sql table, Excel sheet, etc.
 
 The various predefined _storage types_ are mainly used for input data. Indeed, the input data is usually provided by an
-external component, and the data scientist user does not control the format.
+external component, and the Python developer user does not control the format.
 
 However, in most cases, particularly for intermediate or output _data nodes_, it is not relevant to prefer one _storage
 type_. The end-user wants to manipulate the corresponding data within the Taipy application. Still, the user does not
-have any particular specifications regarding the _storage type_. In such a case, the data scientist developer is
+have any particular specifications regarding the _storage type_. In such a case, the Python developer is
 recommended to use the default _storage type_ pickle that does not require any configuration.
 
 In case a more specific method to store, read and write the data is needed by the user, Taipy proposes a _Generic data

--- a/docs/manuals/core/config/index.md
+++ b/docs/manuals/core/config/index.md
@@ -2,7 +2,7 @@
 
 In the previous chapter, the few [Taipy Core concepts](../concepts/index.md) are defined.
 
-Taipy Core is an application builder designed to help data scientists turn their algorithms into an interactive
+Taipy Core is an application builder designed to help Python developer turn their algorithms into an interactive
 production-ready data-driven application.
 
 To build such an application, the first step consists in configuring the characteristic and the desired behavior of

--- a/docs/manuals/core/index.md
+++ b/docs/manuals/core/index.md
@@ -1,7 +1,7 @@
 # Taipy Core
 
 The Taipy Core package is a python library made to build powerful and customized data-driven back-end applications.
-It provides the necessary tools to help data scientists transform their algorithms into a complete
+It provides the necessary tools to help Python developer transform their algorithms into a complete
 back-end application.
 
 Taipy Core brings algorithm management to another level: algorithms are now connected to the end-user through


### PR DESCRIPTION
A last one in "manuals/core/concepts/task.md": 
```
A `Task^` is a runnable python code provided by the developer user
(typically
a data scientist). It represents one step among the various data processing steps the user is working on. Concretely, a
_task_ means a python function that can be executed.
```
Should I transform it?

=> JR : No 