### PR TITLE
Update history and site versioning

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -3,8 +3,29 @@ hide:
   - navigation
 ---
 
-# History
+# Change log
 
-## 1.0 (2022-04-07)
+This is the list of changes of each Taipy version.
 
--   `First release.`
+## Community edition : 1.0 (2022-04-07)
+
+- [`taipy-gui`](https://pypi.org/project/taipy-gui/1.0.0/)
+    - Multiple pages support
+    - Binding to global variables
+    - Python expression support in visual element properties
+    - Initial visual element set including tables and charts.
+    - Page content support for Markdown and HTML
+    - Jupyter Notebook support
+- [`taipy-core`](https://pypi.org/project/taipy-core/1.0.0/)
+    - Full configuration system
+    - Data node management (read/write/filter/cache)
+    - Predefined data nodes (CSV, SQL, EXCEL, PICKLE)
+    - Scenario and cycle management
+    - Smart scheduling and execution (Scenario, Pipeline, and Task submission)
+- [`taipy-rest`](https://pypi.org/project/taipy-rest/1.0.0/)
+    - REST APIs on top of the _taipy-core_
+- [`taipy`](https://pypi.org/project/taipy/1.0.0/)
+    - Includes taipy-gui (1.0)
+    - Includes taipy-core (1.0)
+    - Includes taipy-rest (1.0)
+

--- a/docs/manuals/deployment/linux/redhat.md
+++ b/docs/manuals/deployment/linux/redhat.md
@@ -162,7 +162,7 @@ The application is now running locally but is not accessible yet from the Intern
 To expose your application on the Internet, you should use _Nginx_.
 Replace the content of `/etc/nginx/nginx.conf` by the [following](./nginx.conf) or:
 ```
-sudo wget https://docs.taipy.io/en/latest/manuals/deployment/linux/redhat/nginx.conf -O /etc/nginx/nginx.conf
+sudo wget https://docs.taipy.io/en/latest/manuals/deployment/linux/nginx.conf -O /etc/nginx/nginx.conf
 ```
 
 Allow the communication between _Nginx_ and _uWSGI_:

--- a/mkdocs.yml_template
+++ b/mkdocs.yml_template
@@ -1,5 +1,5 @@
 site_name: Taipy
-site_url: [SITE_URL]
+site_url: https://docs.taipy.io/en/release-1.0
 repo_url: https://github.com/avaiga/taipy
 repo_name: taipy
 #strict: true
@@ -150,7 +150,6 @@ plugins:
   - macros:
       module_name: tools/postprocess
 extra:
-  taipy_version: 1.0
   social:
     - icon: fontawesome/brands/twitter
       # replace with your own tweet link below

--- a/tools/fetch_source_files.sh
+++ b/tools/fetch_source_files.sh
@@ -116,11 +116,7 @@ set_version () {
             MODULE_TAG[$mod]=$tag
         fi
     elif [[ $1 = "MKDOCS" ]]; then
-        if grep -Ei 'site_url: https://docs.taipy.io/en/develop' mkdocs.yml_template; then
-            version="develop"
-        else
-            version=$(grep -Ei 'site_url: https://docs.taipy.io/en/release-[0-9].[0-9]' mkdocs.yml_template | grep -oEi [0-9].[0-9])
-        fi
+        version=$(grep -Ei 'site_url: https://docs.taipy.io/en/(develop|release-[0-9].[0-9])' mkdocs.yml_template | grep -oEi [0-9].[0-9] || echo 'develop')
         set_version $version
     else
         echo "Error: Invalid version in -version parameter: $1" >&2

--- a/tools/fetch_source_files.sh
+++ b/tools/fetch_source_files.sh
@@ -116,10 +116,10 @@ set_version () {
             MODULE_TAG[$mod]=$tag
         fi
     elif [[ $1 = "MKDOCS" ]]; then
-        if grep -Ei 'taipy_version: develop' mkdocs.yml_template; then
+        if grep -Ei 'site_url: https://docs.taipy.io/en/develop' mkdocs.yml_template; then
             version="develop"
         else
-            version=$(grep -Ei 'taipy_version: ([0-9].[0-9])' mkdocs.yml_template | grep -oEi [0-9].[0-9])
+            version=$(grep -Ei 'site_url: https://docs.taipy.io/en/release-[0-9].[0-9]' mkdocs.yml_template | grep -oEi [0-9].[0-9])
         fi
         set_version $version
     else

--- a/tools/postprocess.py
+++ b/tools/postprocess.py
@@ -134,10 +134,6 @@ def on_post_build(env):
                         html_content, n_changes = GS_DOCLINK.subn(f"\\1{gs_rel_path}\\2", html_content)
                         if n_changes != 0:
                             file_was_changed = True
-                        GS_DOCLINK = re.compile(r"(href=\")http://docs\.taipy\.io/en/latest(.*?\")", re.M | re.S)
-                        html_content, n_changes = GS_DOCLINK.subn(f"\\1{env.conf['site_url']}\\2", html_content)
-                        if n_changes != 0:
-                            file_was_changed = True
                     # Add external link icons
                     # Note we want this only for the simple [text](http*://ext_url) cases
                     EXTLINK = re.compile(

--- a/tools/setup_generation.py
+++ b/tools/setup_generation.py
@@ -103,7 +103,7 @@ def restore_top_package_location():
 # Step 1
 #   Generating the Visual Elements documentation
 # ------------------------------------------------------------------------
-print("Step 1/4: Generating Visual Elements documentation")
+print("Step 1/3: Generating Visual Elements documentation")
 
 
 def read_skeleton(name):
@@ -316,7 +316,7 @@ with open(os.path.join(GUI_DOC_PATH, "blocks.md"), "w") as file:
 # Step 2
 #   Generating the Reference Manual
 # ------------------------------------------------------------------------
-print("Step 2/4: Generating the Reference Manual pages")
+print("Step 2/3: Generating the Reference Manual pages")
 
 # Create empty REFERENCE_DIR_PATH directory
 if os.path.exists(REFERENCE_DIR_PATH):
@@ -497,7 +497,7 @@ with open(XREFS_PATH, "w") as xrefs_output_file:
 # Step 3
 #   Generating the Getting Started
 # ------------------------------------------------------------------------
-print("Step 3/4: Generating the Getting Started navigation bar")
+print("Step 3/3: Generating the Getting Started navigation bar")
 
 def format_getting_started_navigation(filepath: str) -> str:
     readme_path = f"{filepath}/ReadMe.md".replace('\\', '/')
@@ -512,29 +512,8 @@ step_folders = map(format_getting_started_navigation, step_folders)
 getting_started_navigation = "\n".join(step_folders) + '\n'
 
 
-
-
-# ------------------------------------------------------------------------
-# Step 4
-#   Generating site url
-# ------------------------------------------------------------------------
-print("Step 4/4: Generating the Site URL")
-tag = re.search(r'taipy_version: (?:develop|(?:(\d+)\.(\d+)))', mkdocs_yml_content)
-
-if not tag.group(1):
-    site_url = f"https://docs.taipy.io/develop"
-else:
-    tag_major = tag.group(1)
-    tag_minor = tag.group(2)
-    site_url = f"https://docs.taipy.io/release/{tag_major}.{tag_minor}"
-
-
-
 # Update mkdocs.yml
 copyright_content = f"{str(datetime.now().year)}"
-mkdocs_yml_content = re.sub(r"\[SITE_URL\]",
-                            site_url,
-                            mkdocs_yml_content)
 mkdocs_yml_content = re.sub(r"\[YEAR\]",
                             copyright_content,
                             mkdocs_yml_content)


### PR DESCRIPTION
Even if the _site_url_ is equal to _https://docs.taipy.io/en/release-1.0_, we can redirect from _https://docs.taipy.io/en/release-1.0_ to _https://docs.taipy.io/en/latest_ and thus deploy this version as "latest".
The only problem is that the redirect should follow the versions, and so we have to manage it.

Readthedocs redirection rule:
```
Redirection exacte
/en/release-1.0/$rest -> /en/latest/
```