### PR TITLE
Add links to taipy-gui's chart example source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ docs/manuals/xrefs
 docs/manuals/reference_rest/*.md
 !docs/manuals/reference_rest/index.md
 docs/manuals/reference_guiext/
+node_modules/
 
 # Getting started
 docs/getting_started/getting-started/*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Taipy Doc
 
 ## License
-Copyright 2022 Avaiga Private Limited
+Copyright 2023 Avaiga Private Limited
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at

--- a/docs/manuals/deployment/docker/nginx.conf
+++ b/docs/manuals/deployment/docker/nginx.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 Avaiga Private Limited
+# Copyright 2023 Avaiga Private Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License. You may obtain a copy of the License at

--- a/docs/manuals/deployment/linux/nginx.conf
+++ b/docs/manuals/deployment/linux/nginx.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 Avaiga Private Limited
+# Copyright 2023 Avaiga Private Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License. You may obtain a copy of the License at

--- a/docs/manuals/gui/viselements/charts/advanced.md
+++ b/docs/manuals/gui/viselements/charts/advanced.md
@@ -4,7 +4,7 @@ Taipy exposes advanced features that the Plotly library provides. This section
 demonstrates some of those features, when they are needed and how to use them
 in your Taipy application.
 
-## Multiple traces with different dataset sizes {data-source="gui:doc/examples/charts/advanced-unbalanced-datasets"}
+## Multiple traces with different dataset sizes {data-source="gui:doc/examples/charts/advanced-unbalanced-datasets.py"}
 
 The [*Adding a trace*](basics.md#adding-a-trace) example explained how to create multiple
 traces on the same chart.<br/>
@@ -100,7 +100,7 @@ Here is what the resulting plot looks like:
     <figcaption>Unbalanced data sets</figcaption>
 </figure>
 
-## Adding annotations {data-source="gui:doc/examples/charts/advanced-annotations"}
+## Adding annotations {data-source="gui:doc/examples/charts/advanced-annotations.py"}
 
 You can add text annotations on top of a chart using the *annotations* property of
 the dictionary set to the [*layout*](../chart.md#p-layout) property of the chart
@@ -185,7 +185,7 @@ Here is how the annotated chart control shows on the page:
     <figcaption>Text annotations</figcaption>
 </figure>
 
-## Adding shapes {data-source="gui:doc/examples/charts/advanced-shapes"}
+## Adding shapes {data-source="gui:doc/examples/charts/advanced-shapes.py"}
 
 Shapes can be rendered on top of a chart at defined locations.<br/>
 To create shapes, you must add shape descriptors to the *shapes* property of
@@ -266,7 +266,7 @@ And here is what the resulting chart looks like:
     <figcaption>Shapes on chart</figcaption>
 </figure>
 
-## Tracking selection {data-source="gui:doc/examples/charts/advanced-selection"}
+## Tracking selection {data-source="gui:doc/examples/charts/advanced-selection.py"}
 
 The chart control has the [*selected*](../chart.md#p-selected) property
 that can be used to track data point selection in the chart control.<br/>
@@ -348,7 +348,7 @@ And here is what the resulting page looks like:
 </figure>
 
 <!--- TODO: when range tracking works.. say... better
-## Tracking range changes {data-source="gui:doc/examples/charts/advanced-range-tracking"}
+## Tracking range changes {data-source="gui:doc/examples/charts/advanced-range-tracking.py"}
 
 You can be notified when the visible range of the chart is changed. That happens when the
 user zooms or pans the chart content using the Zoom or Pan tools.

--- a/docs/manuals/gui/viselements/charts/bar.md
+++ b/docs/manuals/gui/viselements/charts/bar.md
@@ -19,7 +19,7 @@ in the chart control is set to "bar".
 
 ## Examples
 
-### Simple bar chart {data-source="gui:doc/examples/charts/bar-simple"}
+### Simple bar chart {data-source="gui:doc/examples/charts/bar-simple.py"}
 
 Here is an example of how to use bar charts in an application.
 
@@ -63,7 +63,7 @@ has picked up):
     <figcaption>Simple bar chart</figcaption>
 </figure>
 
-### Multiple data sets {data-source="gui:doc/examples/charts/bar-multiple"}
+### Multiple data sets {data-source="gui:doc/examples/charts/bar-multiple.py"}
 
 Say you want to display the score of the winning side next to the
 score of the losing side.
@@ -105,7 +105,7 @@ Here is how this new data set is represented:
     <figcaption>Multiple data sets</figcaption>
 </figure>
 
-### Stacked bar chart {data-source="gui:doc/examples/charts/bar-stacked"}
+### Stacked bar chart {data-source="gui:doc/examples/charts/bar-stacked.py"}
 
 When different data sets are available from the same set of *x* values, it
 may be relevant to stack those values in the same bar.
@@ -144,7 +144,7 @@ Here is the resulting image:
 
 And each bar adds up to 100, as expected.
 
-### Facing bar charts {data-source="gui:doc/examples/charts/bar-facing"}
+### Facing bar charts {data-source="gui:doc/examples/charts/bar-facing.py"}
 
 It's sometimes helpful to display two bar charts facing each other 
 so comparing data is more manageable.

--- a/docs/manuals/gui/viselements/charts/basics.md
+++ b/docs/manuals/gui/viselements/charts/basics.md
@@ -15,7 +15,7 @@ in different situations. It also shows basic customization hints.
 
 ## Examples
 
-### Plotting a series of values {data-source="gui:doc/examples/charts/basics-simple"}
+### Plotting a series of values {data-source="gui:doc/examples/charts/basics-simple.py"}
 
 Say you want to create a line chart connecting a series of values.<br/>
 The *x* values will be the index of each plotted value.
@@ -45,7 +45,7 @@ Here is how this chart is displayed:
     <figcaption>Plotting a series</figcaption>
 </figure>
 
-### Defining the range for *x* {data-source="gui:doc/examples/charts/basics-xrange"}
+### Defining the range for *x* {data-source="gui:doc/examples/charts/basics-xrange.py"}
 
 The example above does not explicitly define an *x* axis: we use the index of the
 *y* value in the input array.<br/>
@@ -103,7 +103,7 @@ The resulting image is the following:
 Note that the axes now have relevant names: because the series are named in
 the source data, both the *x* and *y* axes are labeled accordingly.
 
-### Decorating a chart {data-source="gui:doc/examples/charts/basics-title"}
+### Decorating a chart {data-source="gui:doc/examples/charts/basics-title.py"}
 
 In the first example, you may have noticed the '0' sitting under
 the *x* axis. This is the 'name' of the axis. Because we were not using
@@ -155,7 +155,7 @@ The result is the following:
     <figcaption>Title and x axis label</figcaption>
 </figure>
 
-### Adding a trace {data-source="gui:doc/examples/charts/basics-multiple-traces"}
+### Adding a trace {data-source="gui:doc/examples/charts/basics-multiple.py"}
 
 You will often want to display several traces in the same chart control.
 
@@ -214,7 +214,7 @@ If you want to change the color of a trace, you can use the
 [*color*](../chart.md#p-color) property: setting *color[2]* to "red" will impact the
 color of the second trace, so it is displayed in red.
 
-### Adding a *y* axis {data-source="gui:doc/examples/charts/basics-two-y-axis"}
+### Adding a *y* axis {data-source="gui:doc/examples/charts/basics-two-y-axis.py"}
 
 Let us look at a situation where the two *y* series use ranges that are very
 different:
@@ -317,7 +317,7 @@ The resulting plot is far more relevant:
     <figcaption>Second <i>y</i> axis</figcaption>
 </figure>
 
-### Using a time series {data-source="gui:doc/examples/charts/basics-timeline"}
+### Using a time series {data-source="gui:doc/examples/charts/basics-timeline.py"}
 
 Many charts will represent data that is based on a timeline. Taipy allows you
 to define an *x* axis that represents a time range.

--- a/docs/manuals/gui/viselements/charts/bubble.md
+++ b/docs/manuals/gui/viselements/charts/bubble.md
@@ -19,7 +19,7 @@ the data points get rendered.
 
 ## Examples
 
-### Simple bubble chart {data-source="gui:doc/examples/charts/bubble-simple"}
+### Simple bubble chart {data-source="gui:doc/examples/charts/bubble-simple.py"}
 
 A simple use case for bubble charts is a data set where data points have a related color,
 size, and opacity to be applied for their representation.
@@ -69,7 +69,7 @@ The result looks like this:
     <figcaption>Simple bubble chart</figcaption>
 </figure>
 
-### Setting data point symbols {data-source="gui:doc/examples/charts/bubble-symbols"}
+### Setting data point symbols {data-source="gui:doc/examples/charts/bubble-symbols.py"}
 
 Setting the symbol that is used for every data point is a matter of setting
 the *symbol* property of the dictionary used in the chart control's
@@ -119,7 +119,7 @@ And the resulting chart looks like this:
     <figcaption>Bubble chart symbols</figcaption>
 </figure>
 
-### Hover text {data-source="gui:doc/examples/charts/bubble-hover"}
+### Hover text {data-source="gui:doc/examples/charts/bubble-hover.py"}
 
 You can customize the text that would appear should the user move the pointing
 device on top of a data point symbol.<br/>

--- a/docs/manuals/gui/viselements/charts/candlestick.md
+++ b/docs/manuals/gui/viselements/charts/candlestick.md
@@ -23,7 +23,7 @@ property is set to "candlestick".
 
 ## Examples
 
-### Simple candlestick chart {data-source="gui:doc/examples/charts/candlestick-simple"}
+### Simple candlestick chart {data-source="gui:doc/examples/charts/candlestick-simple.py"}
 
 The following example creates a candlestick chart for the AAPL stock price. It shows all
 the relevant daily information for an entire month.
@@ -69,7 +69,7 @@ The chart is displayed like this:
     <figcaption>Simple candlestick chart</figcaption>
 </figure>
 
-### Styling candlestick charts {data-source="gui:doc/examples/charts/candlestick-styling"}
+### Styling candlestick charts {data-source="gui:doc/examples/charts/candlestick-styling.py"}
 
 By default, Plotly creates green candlestick bars when the value grows (when *close* is
 greater than *open*) and red candlestick bars when the value decreases.<br/>
@@ -141,7 +141,7 @@ This is what the customized candlestick chart looks like:
     <figcaption>Styling candlestick charts</figcaption>
 </figure>
 
-### Using a time series {data-source="gui:doc/examples/charts/candlestick-timeseries"}
+### Using a time series {data-source="gui:doc/examples/charts/candlestick-timeseries.py"}
 
 So far, the *x* values were taken from the Pandas DataFrame that was built by the
 [*yfinance*](https://pypi.org/project/yfinance/) API: the *index* of the DataFrame

--- a/docs/manuals/gui/viselements/charts/continuous-error.md
+++ b/docs/manuals/gui/viselements/charts/continuous-error.md
@@ -20,7 +20,7 @@ usually displayed under the reference trace, created as a
 
 ## Examples
 
-### Simple continuous error band {data-source="gui:doc/examples/charts/continuous-error-simple"}
+### Simple continuous error band {data-source="gui:doc/examples/charts/continuous-error-simple.py"}
 
 Here is a complete example that demonstrates how to create a continuous
 error band.
@@ -116,7 +116,7 @@ Here is the result:
     <figcaption>Continuous Error</figcaption>
 </figure>
 
-### Multiple bands {data-source="gui:doc/examples/charts/continuous-error-multiple"}
+### Multiple bands {data-source="gui:doc/examples/charts/continuous-error-multiple.py"}
 
 Of course, you may need to display several traces with their related
 continuous error bands.<br/>

--- a/docs/manuals/gui/viselements/charts/error-bars.md
+++ b/docs/manuals/gui/viselements/charts/error-bars.md
@@ -21,7 +21,7 @@ for a complete description of these settings.
 
 ## Examples
 
-### Simple error bars {data-source="gui:doc/examples/charts/error-bars-simple"}
+### Simple error bars {data-source="gui:doc/examples/charts/error-bars-simple.py"}
 
 The example shown here creates two traces in the same chart: one is a perfect sine trace,
 and the other is the same sine trace, except that the *y* values of its data points are
@@ -86,7 +86,7 @@ Here is the result:
     <figcaption>Simple error bars</figcaption>
 </figure>
 
-### Asymmetric error bars {data-source="gui:doc/examples/charts/error-bars-asymmetric"}
+### Asymmetric error bars {data-source="gui:doc/examples/charts/error-bars-asymmetric.py"}
 
 The previous example uses an error range applied to every data point. The error
 bar of each data point would represent the whole error range as a segment centered on

--- a/docs/manuals/gui/viselements/charts/filled-area.md
+++ b/docs/manuals/gui/viselements/charts/filled-area.md
@@ -21,7 +21,7 @@ of the Plotly documentation
 
 ## Examples
 
-### Simple filled area chart {data-source="gui:doc/examples/charts/filled-area-simple"}
+### Simple filled area chart {data-source="gui:doc/examples/charts/filled-area-simple.py"}
 
 Here is how we can create a filled area chart to represent the number of items sold every
 weekday:
@@ -65,7 +65,7 @@ The resulting chart is displayed as follows:
     <figcaption>Filled area chart</figcaption>
 </figure>
 
-### Overlayed filled areas {data-source="gui:doc/examples/charts/filled-area-overlay"}
+### Overlayed filled areas {data-source="gui:doc/examples/charts/filled-area-overlay.py"}
 
 Suppose we want also to visualize the price of the items.<br/>
 One way of doing this could be to overlay the two traces on top of each other.
@@ -121,7 +121,7 @@ Here is what the result looks like:
     <figcaption>Overlay of Area Charts</figcaption>
 </figure>
 
-### Stacked Area Chart {data-source="gui:doc/examples/charts/filled-area-stacked"}
+### Stacked Area Chart {data-source="gui:doc/examples/charts/filled-area-stacked.py"}
 
 Multiple traces in a filled area chart can also be displayed as a stack of traces.
 
@@ -174,7 +174,7 @@ Here is the resulting display:
     <figcaption>Stacking areas</figcaption>
 </figure>
 
-### Normalized Stacked Area Chart {data-source="gui:doc/examples/charts/filled-area-normalized"}
+### Normalized Stacked Area Chart {data-source="gui:doc/examples/charts/filled-area-normalized.py"}
 
 Normalizing a stacked area chart makes it easy to visualize relative quantities
 among different data. All values for a given 'x' value are displayed as a

--- a/docs/manuals/gui/viselements/charts/funnel.md
+++ b/docs/manuals/gui/viselements/charts/funnel.md
@@ -28,7 +28,7 @@ of the chart control "funnel" or "funnelarea".
 
 ## Examples
 
-### Simple funnel chart {data-source="gui:doc/examples/charts/funnel-simple"}
+### Simple funnel chart {data-source="gui:doc/examples/charts/funnel-simple.py"}
 
 Here is an example of how to visualize a typical Sales process, looking at how
 many sale opportunities make it through, from the number of leads down to the
@@ -71,7 +71,7 @@ The resulting chart looks like this:
     <figcaption>Simple funnel chart</figcaption>
 </figure>
 
-### Multiple traces {data-source="gui:doc/examples/charts/funnel-multiple"}
+### Multiple traces {data-source="gui:doc/examples/charts/funnel-multiple.py"}
 
 With the previous example, we could spot how many contacts would convert to sales,
 globally for a company.<br/>
@@ -129,7 +129,7 @@ The resulting chart looks like this:
     <figcaption>Funnel chart with multiple traces</figcaption>
 </figure>
 
-### Styling {data-source="gui:doc/examples/charts/funnel-styling"}
+### Styling {data-source="gui:doc/examples/charts/funnel-styling.py"}
 
 Taipy lets you customize how the funnel chart elements can be styled.<br/>
 To indicate how bars and lines should look, use the
@@ -191,7 +191,7 @@ And here is how the resulting funnel chart is displayed:
     <figcaption>Styling funnel charts</figcaption>
 </figure>
 
-### Funnel area chart {data-source="gui:doc/examples/charts/funnel-area"}
+### Funnel area chart {data-source="gui:doc/examples/charts/funnel-area.py"}
 
 A funnel area chart is a kind of funnel chart where boxes, instead of being represented
 as rectangles, appear as stacked trapezoids.<br/>
@@ -249,7 +249,7 @@ The funnel area chart we just created looks like this:
     <figcaption>Funnel area chart</figcaption>
 </figure>
 
-### Multiple funnel charts {data-source="gui:doc/examples/charts/funnel-area-multiple"}
+### Multiple funnel charts {data-source="gui:doc/examples/charts/funnel-area-multiple.py"}
 
 You can create a chart control that represents several funnel charts: Taipy
 lets use of the *domain* property set to the definition of a location

--- a/docs/manuals/gui/viselements/charts/gantt.md
+++ b/docs/manuals/gui/viselements/charts/gantt.md
@@ -55,7 +55,7 @@ If you need to display the *end* date instead, this is what you need to do:
 
 ## Examples
 
-### Simple Gantt chart {data-source="gui:doc/examples/charts/gantt-simple"}
+### Simple Gantt chart {data-source="gui:doc/examples/charts/gantt-simple.py"}
 
 Here is a simple example of using the chart control to display a Gantt chart.
 

--- a/docs/manuals/gui/viselements/charts/heatmap.md
+++ b/docs/manuals/gui/viselements/charts/heatmap.md
@@ -27,7 +27,7 @@ of the chart control to "heatmap".
 
 ## Examples
 
-### Simple Heatmap {data-source="gui:doc/examples/charts/heatmap-simple"}
+### Simple Heatmap {data-source="gui:doc/examples/charts/heatmap-simple.py"}
 
 This example displays a heatmap representing the temperatures, in °C, in some cities during
 a given season (of the northern hemisphere).
@@ -76,7 +76,7 @@ And here is how the resulting chart will look like on the page:
     <figcaption>Temperatures</figcaption>
 </figure>
 
-### Unbalanced Heatmap {data-source="gui:doc/examples/charts/heatmap-unbalanced"}
+### Unbalanced Heatmap {data-source="gui:doc/examples/charts/heatmap-unbalanced.py"}
 
 The example above was an example where the size of the datasets for the *x* and *y*
 axes was the same.
@@ -138,7 +138,7 @@ And the chart displays as expected:
     <figcaption>Temperatures</figcaption>
 </figure>
 
-### Setting the color scale {data-source="gui:doc/examples/charts/heatmap-colorscale"}
+### Setting the color scale {data-source="gui:doc/examples/charts/heatmap-colorscale.py"}
 
 If you want to change the color scale used in the heatmap cells, you must set the *colorscale*
 property of the property [*options*](../../chart/#p-options) of the chart control.<br/>
@@ -179,7 +179,7 @@ Here is how the page looks like:
     <figcaption>Specific Color Scale</figcaption>
 </figure>
 
-### Annotated Heatmap {data-source="gui:doc/examples/charts/heatmap-annotated"}
+### Annotated Heatmap {data-source="gui:doc/examples/charts/heatmap-annotated.py"}
 
 You may need to display some information in the cells of a heatmap.
 
@@ -264,7 +264,7 @@ And the result looks like this:
     <figcaption>Annotated Heatmap</figcaption>
 </figure>
 
-### Unequal Cell Sizes {data-source="gui:doc/examples/charts/heatmap-unequal-cell-sizes"}
+### Unequal Cell Sizes {data-source="gui:doc/examples/charts/heatmap-unequal-cell-sizes.py"}
 
 You may need to specify the size of each heatmap cell, both in the horizontal and the vertical
 dimensions.
@@ -341,7 +341,7 @@ Here is resulting chart:
     <figcaption>Unequal cell sizes</figcaption>
 </figure>
 
-### Drawing on top of a heatmap {data-source="gui:doc/examples/charts/heatmap-drawing-on-top"}
+### Drawing on top of a heatmap {data-source="gui:doc/examples/charts/heatmap-drawing-on-top.py"}
 
 You can even add another trace on top of a heatmap.
 

--- a/docs/manuals/gui/viselements/charts/histogram.md
+++ b/docs/manuals/gui/viselements/charts/histogram.md
@@ -21,7 +21,7 @@ property for a trace set to "histogram".
 
 ## Examples
 
-### Simple histogram {data-source="gui:doc/examples/charts/histogram-simple"}
+### Simple histogram {data-source="gui:doc/examples/charts/histogram-simple.py"}
 
 The simplest histogram would use a data set and represent the number of
 data points that fall in a given bin (between two fixed values).
@@ -70,7 +70,7 @@ data = {
 Then Taipy would have been able to extract the name of the data set and
 use it as the axis label (as you can see in the following example).
 
-### Horizontal histogram {data-source="gui:doc/examples/charts/histogram-horizontal"}
+### Horizontal histogram {data-source="gui:doc/examples/charts/histogram-horizontal.py"}
 
 To display a histogram horizontally (where the values count appear in horizontal bars),
 we can simply set the data set as the value of the [_y_](../chart.md#p-y) property
@@ -108,7 +108,7 @@ The resulting chart looks as follows:
     <figcaption>Horizontal histogram</figcaption>
 </figure>
 
-### Overlying data sets {data-source="gui:doc/examples/charts/histogram-overlay"}
+### Overlying data sets {data-source="gui:doc/examples/charts/histogram-overlay.py"}
 
 You can display several data sets in the same histogram. One way of representing
 this would be to overlay the two histogram displays (and apply some transparency
@@ -178,7 +178,7 @@ Here is what the resulting chart looks like:
     <figcaption>Overlaid data sets</figcaption>
 </figure>
 
-### Stacked data sets {data-source="gui:doc/examples/charts/histogram-stacked"}
+### Stacked data sets {data-source="gui:doc/examples/charts/histogram-stacked.py"}
 
 Histograms can also represent different data sets accumulating their bin
 counts on top of one another.<br/>
@@ -231,7 +231,7 @@ To result in the following figure:
     <figcaption>Stacked data sets</figcaption>
 </figure>
 
-### Cumulative histogram {data-source="gui:doc/examples/charts/histogram-cumulative"}
+### Cumulative histogram {data-source="gui:doc/examples/charts/histogram-cumulative.py"}
 
 Histograms can also represent the sum of the number of observations, bin after
 bin.<br/>
@@ -277,7 +277,7 @@ The resulting chart looks like this:
 It's no surprise to see the count grow to 500, which is the size of
 our initial data set.
 
-### Normalized histogram {data-source="gui:doc/examples/charts/histogram-normalized"}
+### Normalized histogram {data-source="gui:doc/examples/charts/histogram-normalized.py"}
 
 Instead of displaying the count of bins, histograms can also be customized to display
 the proportion of each bin.<br/>
@@ -323,7 +323,7 @@ Here is what the chart looks like:
     <figcaption>Normalized histogram</figcaption>
 </figure>
 
-### Specifying the binning function {data-source="gui:doc/examples/charts/histogram-binning"}
+### Specifying the binning function {data-source="gui:doc/examples/charts/histogram-binning-function.py"}
 
 Histograms usually represent the count of observations for each bin. However, you
 may want to reflect other information on the data set, such as how many times
@@ -397,7 +397,7 @@ The page shows:
     <figcaption>Different binning-functions</figcaption>
 </figure>
 
-### Tuning bins {data-source="gui:doc/examples/charts/histogram-nbins"}
+### Tuning bins {data-source="gui:doc/examples/charts/histogram-nbins.py"}
 
 Histograms can be customized to force the number of bins that Plotly
 computes when facing data sets.<br/>

--- a/docs/manuals/gui/viselements/charts/line.md
+++ b/docs/manuals/gui/viselements/charts/line.md
@@ -20,7 +20,7 @@ relevant to this type of chart only.
 
 ## Examples
 
-### Styling lines {data-source="gui:doc/examples/charts/line-style"}
+### Styling lines {data-source="gui:doc/examples/charts/line-style.py"}
 
 You can style plots using the [*line[]*](../chart.md#p-line) and
 [*color[]*](../chart.md#p-color) properties.
@@ -67,7 +67,7 @@ The page now shows the following chart:
     <figcaption>Styling a line chart</figcaption>
 </figure>
 
-### Text above plot {data-source="gui:doc/examples/charts/line-text"}
+### Text above plot {data-source="gui:doc/examples/charts/line-texts.py"}
 
 It is sometimes useful to provide textual information on top of a plot.
 Here is how to do that in the context of a line chart.

--- a/docs/manuals/gui/viselements/charts/map.md
+++ b/docs/manuals/gui/viselements/charts/map.md
@@ -19,7 +19,7 @@ manual for [*scattergeo* traces](https://plotly.com/javascript/reference/scatter
 
 ## Examples
 
-### Simple map {data-source="gui:doc/examples/charts/map-simple"}
+### Simple map {data-source="gui:doc/examples/charts/map-simple.py"}
 
 Here is a simple example demonstrating how to plot a line between two
 georeferenced locations.
@@ -92,7 +92,7 @@ The control renders as shown here:
     <figcaption>Flight path</figcaption>
 </figure>
 
-### Multiple paths {data-source="gui:doc/examples/charts/map-lines"}
+### Multiple paths {data-source="gui:doc/examples/charts/map-lines.py"}
 
 If you need to display several distinct paths on top of a map, you must create a trace
 for each.
@@ -205,7 +205,7 @@ Here is how the chart control is displayed:
     <figcaption>US flights</figcaption>
 </figure>
 
-### Bubbles on map {data-source="gui:doc/examples/charts/map-bubbles"}
+### Bubbles on map {data-source="gui:doc/examples/charts/map-bubbles.py"}
 
 You may need to represent some value at their appropriate location.
 

--- a/docs/manuals/gui/viselements/charts/pie.md
+++ b/docs/manuals/gui/viselements/charts/pie.md
@@ -19,7 +19,7 @@ to "pie" to create a pie chart.
 
 ## Examples
 
-### Simple pie chart {data-source="gui:doc/examples/charts/pie-simple"}
+### Simple pie chart {data-source="gui:doc/examples/charts/pie-simple.py"}
 
 In this example, we want to represent the area covered by forests around the world. Only the
 first few countries are represented since too many would make the chart unreadable.
@@ -64,7 +64,7 @@ Here is the resulting chart:
     <figcaption>Simple pie chart</figcaption>
 </figure>
 
-### Styling {data-source="gui:doc/examples/charts/pie-styling"}
+### Styling {data-source="gui:doc/examples/charts/pie-styling.py"}
 
 You can specify what the color of each slice should be.
 
@@ -126,7 +126,7 @@ The colored pie chart renders as follows:
     <figcaption>Styling</figcaption>
 </figure>
 
-### Multiple charts {data-source="gui:doc/examples/charts/pie-multiple"}
+### Multiple charts {data-source="gui:doc/examples/charts/pie-multiple.py"}
 
 You can create a chart control that holds several pie charts and display
 them together.

--- a/docs/manuals/gui/viselements/charts/polar.md
+++ b/docs/manuals/gui/viselements/charts/polar.md
@@ -23,7 +23,7 @@ of the chart control to "scatterpolar", and set the [*r*](../chart.md#p-r) and
 
 ## Examples
 
-### Simple polar chart {data-source="gui:doc/examples/charts/polar-simple"}
+### Simple polar chart {data-source="gui:doc/examples/charts/polar-simple.py"}
 
 A typical use case for polar charts is when you have a parametric
 equation to represent, based on an angular value.
@@ -81,7 +81,7 @@ Here is the result:
     <figcaption>Simple polar chart</figcaption>
 </figure>
 
-### Areas {data-source="gui:doc/examples/charts/polar-area"}
+### Areas {data-source="gui:doc/examples/charts/polar-area.py"}
 
 Filling an area in a polar chart is only a matter of setting the *fill* property of
 the value assigned to the [*options*](../chart.md#p-options) property of the chart control.
@@ -139,7 +139,7 @@ Here is the result:
     <figcaption>Area in a polar chart</figcaption>
 </figure>
 
-### Multiple traces {data-source="gui:doc/examples/charts/polar-multiple"}
+### Multiple traces {data-source="gui:doc/examples/charts/polar-multiple.py"}
 
 Several traces can be displayed in the same polar chart. The [*r*](../chart.md#p-r)
 indexed property can refer to different data.
@@ -209,7 +209,7 @@ Here is what the chart looks like:
     <figcaption>Multiple traces</figcaption>
 </figure>
 
-### Specifying the angular range {data-source="gui:doc/examples/charts/polar-sector"}
+### Specifying the angular range {data-source="gui:doc/examples/charts/polar-sectors.py"}
 
 It may be necessary not to display the entire 360° of the chart but instead select a
 range of angles to represent: a *sector*.
@@ -277,7 +277,7 @@ Here are our two traces, gathered in the same chart:
     <figcaption>Specifying a sector</figcaption>
 </figure>
 
-### Angular axis settings {data-source="gui:doc/examples/charts/polar-angular-axis"}
+### Angular axis settings {data-source="gui:doc/examples/charts/polar-angular-axis.py"}
 
 The angular axis can be tuned to set its origin wherever needed. It can
 also be oriented, and the angular values can appear in different units.
@@ -355,7 +355,7 @@ The two traces appear in the chart, mirroring one another:
     <figcaption>Customizing the angular axis</figcaption>
 </figure>
 
-### Setting tick texts {data-source="gui:doc/examples/charts/polar-tick-texts"}
+### Setting tick texts {data-source="gui:doc/examples/charts/polar-tick-texts.py"}
 
 You can also customize what the tick texts are: what text is at what location on the axis.
 

--- a/docs/manuals/gui/viselements/charts/radar.md
+++ b/docs/manuals/gui/viselements/charts/radar.md
@@ -24,7 +24,7 @@ radar chart automatically arranges all categories along the angular axis.
 
 ## Examples
 
-### Simple radar chart {data-source="gui:doc/examples/charts/radar-simple"}
+### Simple radar chart {data-source="gui:doc/examples/charts/radar-simple.py"}
 
 Here is an example that demonstrates the use of a radar chart to display
 the relative usage of programming languages among developers:
@@ -88,7 +88,7 @@ Here is the resulting figure:
     <figcaption>Simple radar chart</figcaption>
 </figure>
 
-### Multiple data sets {data-source="gui:doc/examples/charts/radar-multiple"}
+### Multiple data sets {data-source="gui:doc/examples/charts/radar-multiple.py"}
 
 Radar charts are handy when used to compare two data sets: one can immediately spot
 where a given data set performs better or worse than another for a given category.

--- a/docs/manuals/gui/viselements/charts/scatter.md
+++ b/docs/manuals/gui/viselements/charts/scatter.md
@@ -19,7 +19,7 @@ In order to create scatter charts with Taipy, you need to set the
 
 ## Examples
 
-### Classification {data-source="gui:doc/examples/charts/scatter-classification"}
+### Classification {data-source="gui:doc/examples/charts/scatter-classification.py"}
 
 Using a scatter chart to represent the result of the classification of
 samples is really relevant: you can use different colors to represent
@@ -72,7 +72,7 @@ The resulting chart is:
     <figcaption>Classification</figcaption>
 </figure>
 
-### Customizing a scatter chart {data-source="gui:doc/examples/charts/scatter-styling"}
+### Customizing a scatter chart {data-source="gui:doc/examples/charts/scatter-styling.py"}
 
 A common problem with scatter charts is that individual markers can be displayed
 on top of each other. This may result in markers being hidden by others, and
@@ -130,7 +130,7 @@ That generates the following chart:
     <figcaption>Styling markers</figcaption>
 </figure>
 
-### Customizing individual data points {data-source="gui:doc/examples/charts/scatter-more-styling"}
+### Customizing individual data points {data-source="gui:doc/examples/charts/scatter-more-styling.py"}
 
 Changing the style of markers can also be set for each individual data point.
 
@@ -222,7 +222,7 @@ The resulting chart displays as:
     <figcaption>Styling data points</figcaption>
 </figure>
 
-### Regression {data-source="gui:doc/examples/charts/scatter-regression"}
+### Regression {data-source="gui:doc/examples/charts/scatter-regression.py"}
 
 Regression is an excellent use case for using scatter charts: on top of samples data
 points, you can trace the plot of a function that best fits the data points.

--- a/tools/_fetch_source_file/utils.py
+++ b/tools/_fetch_source_file/utils.py
@@ -10,7 +10,7 @@ def read_doc_version_from_mkdocs_yml_template_file(root_dir):
         mkdocs_yml_template = mkdocs_file.read()
     if mkdocs_yml_template is None:
         raise IOError(f"Couldn't open '{mkdocs_yml_template_path}'")
-    mkdocs_yml_version = re.search(r"site_url:\s*https://docs\.taipy\.io/en/(develop|release-(\d\.\d))$",
+    mkdocs_yml_version = re.search(r"site_url:\s*https://docs\.taipy\.io/en/(develop|release-(\d+\.\d+))$",
                                    mkdocs_yml_template, re.MULTILINE)
     if mkdocs_yml_version is None:
         raise ValueError(


### PR DESCRIPTION
- Converts data-source HTML attributes to a link to a file within a Taipy repository
- Update missed copyright dates.