### PR TITLE
Remove taipy.dev@avaiga.com email

### DIFF
--- a/docs/credits/contributors.md_template
+++ b/docs/credits/contributors.md_template
@@ -3,7 +3,7 @@
 Taipy is developed and maintained by Avaiga company and its amazing team:
 [AVAIGA_TEAM_MEMBERS]
 
-[:material-arrow-right: Contact the dev team by email](mailto:taipy.dev@avaiga.com)
+[:material-arrow-right: Contact the dev team by email](mailto:support@taipy.io)
 
 # Contributors
 

--- a/mkdocs.yml_template
+++ b/mkdocs.yml_template
@@ -1,5 +1,5 @@
 site_name: Taipy
-site_url: https://docs.taipy.io/en/develop
+site_url: https://docs.taipy.io/en/release-2.2
 site_description: Documentation for Taipy
 site_author: taipy.io
 repo_url: https://github.com/avaiga/taipy


### PR DESCRIPTION
Replaced by support@taipy.io
