### PR TITLE
taipy.dev email dropped (-> support@taipy.io)

### DIFF
--- a/docs/credits/contributors.md_template
+++ b/docs/credits/contributors.md_template
@@ -3,7 +3,7 @@
 Taipy is developed and maintained by Avaiga company and its amazing team:
 [AVAIGA_TEAM_MEMBERS]
 
-[:material-arrow-right: Contact the dev team by email](mailto:taipy.dev@avaiga.com)
+[:material-arrow-right: Contact the dev team by email](mailto:support@taipy.io)
 
 # Contributors
 


### PR DESCRIPTION
Replaced by [support@taipy.io](mailto:support@taipy.io)