### PR TITLE
Fix/Core#573 - Wrong doc for the type of `read_fct_params` of GenericDataNode on Taipy 2.2

### DIFF
--- a/docs/manuals/core/config/code_example/data_node_cfg/data-node-config_generic-csv.py
+++ b/docs/manuals/core/config/code_example/data_node_cfg/data-node-config_generic-csv.py
@@ -22,5 +22,6 @@ csv_country_data_cfg = Config.configure_generic_data_node(
     id="csv_country_data",
     read_fct=read_csv,
     write_fct=write_csv,
-    read_fct_params=["../path/data.csv", ";"],
-    write_fct_params=["../path/data.csv", ";"])
+    read_fct_params=("../path/data.csv", ";"),
+    write_fct_params=("../path/data.csv", ";"),
+)

--- a/docs/manuals/core/config/code_example/data_node_cfg/data-node-config_generic-data-prep.py
+++ b/docs/manuals/core/config/code_example/data_node_cfg/data-node-config_generic-data-prep.py
@@ -27,5 +27,6 @@ student_data = Config.configure_generic_data_node(
     id="student_data",
     read_fct=read_csv,
     write_fct=write_csv,
-    read_fct_params=["../path/data.csv"],
-    write_fct_params=["../path/data.csv"])
+    read_fct_params=("../path/data.csv", ),
+    write_fct_params=("../path/data.csv", ),
+)

--- a/docs/manuals/core/config/code_example/data_node_cfg/data-node-config_generic-text.py
+++ b/docs/manuals/core/config/code_example/data_node_cfg/data-node-config_generic-text.py
@@ -16,5 +16,6 @@ historical_data_cfg = Config.configure_generic_data_node(
     id="historical_data",
     read_fct=read_text,
     write_fct=write_text,
-    read_fct_params=["../path/data.txt"],
-    write_fct_params=["../path/data.txt"])
+    read_fct_params=("../path/data.txt", ),
+    write_fct_params=("../path/data.txt", ),
+)

--- a/docs/manuals/core/config/data-node-config.md
+++ b/docs/manuals/core/config/data-node-config.md
@@ -739,10 +739,10 @@ can be provided:
   More optional parameters can be passed through the _**write_fct_params**_ parameter.
 
 - _**read_fct_params**_ represents the parameters passed to the _read_fct_ to
-  read/de-serialize the data. It must be a `List` type object.
+  read/de-serialize the data. It must be a `Tuple` type object.
 
 - _**write_fct_params**_ represents the parameters passed to the _write_fct_ to write
-  the data. It must be a `List` type object.
+  the data. It must be a `Tuple` type object.
 
 
 ```python linenums="1"


### PR DESCRIPTION
https://github.com/Avaiga/taipy-core/issues/573