### PR TITLE
Fixes image and link to chatbot demo

### DIFF
--- a/docs/knowledge_base/demos/index.md
+++ b/docs/knowledge_base/demos/index.md
@@ -275,9 +275,9 @@ Let's explore demos of applications made with Taipy.
   </li>
 
   <li class="tp-col-12 tp-col-md-6 d-flex" data-keywords="gui vizelement ai">
-    <a class="tp-content-card tp-content-card--horizontal tp-content-card--small" href="pollution_sensors">
+    <a class="tp-content-card tp-content-card--horizontal tp-content-card--small" href="chatbot">
       <header class="tp-content-card-header">
-        <img class="tp-content-card-image" src="images/chatbot_roundconv.png">
+        <img class="tp-content-card-image" src="images/chatbot_meds_conv.png">
       </header>
       <div class="tp-content-card-body">
         <h4>LLM ChatBot</h4>


### PR DESCRIPTION
On the demos page, the chatbot demo was missing its preview image and it redirected to the wrong demo
![image](https://github.com/Avaiga/taipy-doc/assets/62465003/b62ba448-4fdf-46b5-8fa2-04ff9cf85a65)
