### PR TITLE
Removes src import in page_builder page

### DIFF
--- a/docs/manuals/gui/page_builder.md
+++ b/docs/manuals/gui/page_builder.md
@@ -17,8 +17,8 @@ elements this page holds within the `with` block.
 
 Here is an example of how to create a page using the Page Builder:
 ```py
-from src.taipy.gui import Gui
-import src.taipy.gui.builder as tgb
+from taipy.gui import Gui
+import taipy.gui.builder as tgb
 
 
 with tgb.Page() as page:


### PR DESCRIPTION
Removes src import on this page:
![image](https://github.com/Avaiga/taipy-doc/assets/62465003/2653f1fc-c1c0-44db-915e-d14591453010)

https://docs.taipy.io/en/latest/manuals/gui/page_builder/