### PR TITLE
Fixes Chatbot demo div in knowledge base

### DIFF
--- a/docs/knowledge_base/index.md
+++ b/docs/knowledge_base/index.md
@@ -520,8 +520,16 @@ hide:
 
   <li data-keywords="gui vizelement ai">
     <a class="tp-content-card tp-content-card--horizontal tp-content-card--small" href="demos/chatbot/">
+      <header class="tp-content-card-header">
+        <img class="tp-content-card-icon" src="demos/images/icon-code.svg">
+      </header>
+      <div class="tp-content-card-body">
         <h4> LLM ChatBot </h4>
         <p> A chatbot that uses OpenAI's API with GPT-3. Can be used as a template for implementing apps that use LLM inference.
+        </p>
+      </div> 
+    </a>
+  </li>
 
   <li data-keywords="gui dashboard vizelement layout chart ai multi-page classification">
     <a class="tp-content-card tp-content-card--horizontal tp-content-card--small" href="demos/fraud_detection/">


### PR DESCRIPTION
Fixes chatbot demo incorrect display of div in knowledge base:
![image](https://github.com/Avaiga/taipy-doc/assets/62465003/f57c0836-7b39-4d12-a4e9-98088e67058e)

https://docs.taipy.io/en/develop/knowledge_base/