### PR TITLE
Fixed NameError in Multi-page Application Example

### DIFF
--- a/docs/tutorials/fundamentals/1_understanding_gui/step_07/step_07.md
+++ b/docs/tutorials/fundamentals/1_understanding_gui/step_07/step_07.md
@@ -52,8 +52,8 @@ could have one page created with Markdown and another with the Python API.
 
     pages = {
         "/": root_page,
-        "page1": page1,
-        "page2": page2
+        "page1": page_1,
+        "page2": page_2
     }
     Gui(pages=pages).run()
     ```


### PR DESCRIPTION
Fixed variable names in the pages dictionary from `page1` and `page2` to `page_1` and `page_2` to resolve a NameError in the Taipy GUI multi-page application example.