### PR TITLE
Remove all Taipy Cloud references

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ apispec = {extras = ["yaml"], version = "==6.3"}
 apispec-webframeworks = "==0.5.2"
 bcrypt = "==3.2.2"
 boto3 = "==1.29.1"
+charset-normalizer = "==3.3.2"
 cookiecutter = "==2.1.1"
 deepdiff = "==6.2.2"
 flask = "==3.0.0"
@@ -42,6 +43,7 @@ sqlalchemy = "==2.0.16"
 toml = "==0.10"
 twisted = "==23.8.0"
 tzlocal = "==3.0"
+watchdog = "==4.0.0"
 
 [dev-packages]
 black = "*"

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -20,13 +20,13 @@ first application with ease.
     ```
 
 For alternative installation methods or if you're lacking Python or pip, refer to the
-[installation page](../installation/index.md).
+[installation page](../installation.md).
 
 # Build a graphical interface
 
-In this section, you'll create an application that includes a slider to adjust a 
-parameter, which in turn affects a data visualization chart. This example 
-demonstrates how Taipy can be used to create interactive and dynamic web 
+In this section, you'll create an application that includes a slider to adjust a
+parameter, which in turn affects a data visualization chart. This example
+demonstrates how Taipy can be used to create interactive and dynamic web
 applications.
 
 !!! example "GUI creation"
@@ -69,7 +69,7 @@ applications.
         the Page Builder API.
 
         ```python linenums="1"
-        from taipy.gui import Gui 
+        from taipy.gui import Gui
         import taipy.gui.builder as tgb
         from math import cos, exp
 
@@ -85,7 +85,7 @@ applications.
             tgb.text(value="# Taipy Getting Started", mode="md")
             tgb.text(value="Value: {value}")
             tgb.slider(value="{value}", on_change=on_slider)
-            tgb.chart(data="{data}") 
+            tgb.chart(data="{data}")
 
         data = compute_data(value)
 
@@ -107,15 +107,15 @@ visual element.
 
 In our initial example:
 
-- *value* is bound to a slider and a text, allowing the user’s input to be directly 
+- *value* is bound to a slider and a text, allowing the user’s input to be directly
 stored in the *value* variable.
-- *data* is created through in *compute_data()* function and is updated depending on the  
+- *data* is created through in *compute_data()* function and is updated depending on the
 slider's value. It is represented in the application as a chart.
 
 
 ## Interactivity Through Actions
 
-Actions, like `on_change=on_slider`, allow visual elements like slider or input 
+Actions, like `on_change=on_slider`, allow visual elements like slider or input
 to trigger specific functions.
 
 ```python
@@ -128,8 +128,8 @@ This state represents a user's connection and is used to read and set variables 
 the user is interacting with the application. It makes it possible for Taipy to handle multiple
 users simultaneously.
 
-*state.value* is specific to the user who interacts with the application. 
-This design ensures that each user's actions are separate and efficiently 
+*state.value* is specific to the user who interacts with the application.
+This design ensures that each user's actions are separate and efficiently
 controlled, while other variables could be global variables.
 
 ![State illustration](images/state_illustration.png){width=70% : .tp-image-border }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,7 +64,7 @@ the cell:
     This command installs the latest stable release of Taipy in your Colab environment.
 
 3. **Start building your app**: Follow this
-[tip](../tutorials/integration/2_colab_with_ngrok/index.md) to build and run your Taipy web
+[tip](tutorials/integration/2_colab_with_ngrok/index.md) to build and run your Taipy web
 application directly within the Colab notebook.
 
 !!! tip

--- a/docs/manuals/cli/version.md
+++ b/docs/manuals/cli/version.md
@@ -1,5 +1,5 @@
 # Get Taipy version
-You can check your current installed version of Taipy by running the `taipy --version` (or 
+You can check your current installed version of Taipy by running the `taipy --version` (or
 `taipy -v`) command in a terminal (Linux, macOS) or command prompt (Windows).
 
 ```console
@@ -8,4 +8,4 @@ Taipy 2.3.0
 ```
 
 If you don't see a supported version of Taipy, you'll need to either upgrade Taipy or perform a
-fresh install, as described in the [Installation page](../../installation/index.md).
+fresh install, as described in the [Installation page](../../installation.md).

--- a/docs/manuals/run-deploy/deploy/index.md
+++ b/docs/manuals/run-deploy/deploy/index.md
@@ -3,8 +3,6 @@ may need to deploy it on a remote environment, for end users to be able to use i
 
 Here are the different situations that Taipy can address:
 
-- [Taipy Cloud](taipy-cloud/index.md): deploy the application on the
-  [Taipy Cloud](https://www.taipy.io/cloud/) platform;
 - [Windows](windows/index.md): deploy the application on a Windows Server system;
 - [Linux](linux/index.md): deploy the application on a server running Linux;
 - [Docker](docker/index.md): running the application in a container;
@@ -15,8 +13,6 @@ Here are the different situations that Taipy can address:
 - [Databricks](databricks/index.md): deploy the application on the
   [Databricks](https://www.databricks.com/) platform;
 
-
-## [Taipy Cloud](taipy-cloud/index.md)
 
 ## [Windows](windows/index.md)
 

--- a/docs/manuals/run-deploy/deploy/taipy-cloud/index.md
+++ b/docs/manuals/run-deploy/deploy/taipy-cloud/index.md
@@ -1,3 +1,12 @@
+---
+title: Taipy Cloud
+search:
+  exclude: true
+---
+
+!!! Warning
+    The Taipy Cloud service as been shut down. This page is no longer relevant.
+
 Welcome to Taipy Cloud, the platform designed to make application deployment easier,
 ensuring accessibility and stability. In this detailed guide, we will take you through
 the process of deploying a Taipy application on Taipy Cloud.
@@ -15,7 +24,7 @@ Here are the steps to create this file:
 
 1. In your project directory, create a new file named `requirements.txt`.
 2. List all the dependencies, one per line, as shown in the example below
-3. Create a zip archive containing your project folder, including your application’s 
+3. Create a zip archive containing your project folder, including your application’s
 `requirements.txt` and `main.py` files.
 
 ```py
@@ -26,13 +35,13 @@ pandas
 ```
 
 !!! Warning
-    Using Windows-specific libraries is not supported, as the machines operate 
+    Using Windows-specific libraries is not supported, as the machines operate
     on a Linux environment.
 
 
 ## Step 2: Create an Account on Taipy Cloud
 
-Visit [taipy.io/cloud/](https://www.taipy.io/cloud/) and sign up for an account or sign 
+Visit [taipy.io/cloud/](https://www.taipy.io/cloud/) and sign up for an account or sign
 in with your account if it already exists.
 This will enable you to deploy applications with ease.
 
@@ -44,11 +53,11 @@ on the Taipy Cloud dashboard, you can configure several parameters:
 
 - **Machine name**: Provide a unique name for your machine.
 - **Python version**: Choose from a Python version 3.8, 3.9, 3.10, 3.11, or 3.12.
-- **Machine size**: Select from Small, Medium, or Large, depending on your application's 
+- **Machine size**: Select from Small, Medium, or Large, depending on your application's
 requirements.
-  Larger machines can handle more complex applications simultaneously. The default 
+  Larger machines can handle more complex applications simultaneously. The default
   setting is a small-size machine.
-  If you're a first-time user of Taipy Cloud, you'll also be prompted to create a 
+  If you're a first-time user of Taipy Cloud, you'll also be prompted to create a
   username and password.
   This will allow you to access your machine's logs.
 
@@ -72,32 +81,32 @@ which will be displayed as `<Deployment name>.taipy.cloud`.
 
 The dialog includes two additional sections for further customization:
 
-- **Environment Variables**: This section allows you to inject environment variables 
+- **Environment Variables**: This section allows you to inject environment variables
 and secrets into your applications.
 
-- **Configuration**: Additionally, you have the option to modify the configuration of 
-your Taipy application. This can be done by uploading or changing a 
+- **Configuration**: Additionally, you have the option to modify the configuration of
+your Taipy application. This can be done by uploading or changing a
 [configuration](../../../core/versioning/configuration.md) TOML.
 
 ## Step 5: Test Your App
 
-Once your Taipy application is deployed, you can test it to ensure everything is 
+Once your Taipy application is deployed, you can test it to ensure everything is
 functioning correctly.
-To do this, access it using the provided URL and run through its features, verifying its 
+To do this, access it using the provided URL and run through its features, verifying its
 stability and accessibility.
 
 Additionally, you can access the Console Logs link, which displays application events
-such as warnings, errors, and print statements, offering insights into your 
+such as warnings, errors, and print statements, offering insights into your
 application’s performance.
 
-The Taipy Cloud dashboard provides additional information such as CPU, RAM, and Disk 
+The Taipy Cloud dashboard provides additional information such as CPU, RAM, and Disk
 usage for each machine and application.
 
 ## Connect with SSH or FileZilla
 
-To facilitate the management of your application's files and data, Taipy Cloud supports 
-connections via SSH and FileZilla. This allows you to securely transfer files to and from 
-your cloud machine, which is particularly useful for handling large data sets or files 
+To facilitate the management of your application's files and data, Taipy Cloud supports
+connections via SSH and FileZilla. This allows you to securely transfer files to and from
+your cloud machine, which is particularly useful for handling large data sets or files
 that need to be updated or replaced between deployments.
 
 ![Create a Machine](images/taipy_connection.png){width=90% : .tp-image-border }
@@ -118,25 +127,25 @@ that need to be updated or replaced between deployments.
 
 Open FileZilla and fill in the details as follows:
 
-   - **Host**: `<your-machine-name>.taipy.cloud` - Replace `<your-machine-name>` with the 
+   - **Host**: `<your-machine-name>.taipy.cloud` - Replace `<your-machine-name>` with the
    actual name of your machine.
    - **Username**: Enter your username.
    - **Password**: Enter the  password you have provided for the machine.
 
-**Click Quickconnect**: If everything is configured correctly, FileZilla will establish a 
-secure connection to your Taipy Cloud machine, and you'll be able to start transferring 
+**Click Quickconnect**: If everything is configured correctly, FileZilla will establish a
+secure connection to your Taipy Cloud machine, and you'll be able to start transferring
 files.
 
 ### Best Practices for File Transfer
 
 
-- **Manage File Sizes**: To optimize performance and deployment times, avoid uploading 
+- **Manage File Sizes**: To optimize performance and deployment times, avoid uploading
 unnecessary large files including `__pycache__`, *virtualenv* and *git* files. Use compression when possible.
 
-- **Security**: Always ensure your keys and passwords are secure and not shared with unauthorized 
+- **Security**: Always ensure your keys and passwords are secure and not shared with unauthorized
 individuals.
 
-In conclusion, Taipy Cloud is an easy platform for deploying your Taipy applications 
+In conclusion, Taipy Cloud is an easy platform for deploying your Taipy applications
 with ease.
-By following these straightforward steps, you can ensure that your application remains 
+By following these straightforward steps, you can ensure that your application remains
 accessible and stable.

--- a/docs/manuals/run-deploy/index.md
+++ b/docs/manuals/run-deploy/index.md
@@ -22,12 +22,9 @@ configure the system where you want the application to run:
 - The application can run locally on your machine.<br/>
   It can, however, be exposed to external users through the Internet if that is something
   you need.
-- The application can be deployed to [Taipy Cloud](deploy/taipy-cloud/index.md), that
-  provides the hardware, management and supervision utilities to host your application outside
-  your IT environment.
 - Vendors provide different services that deal with computing, storage, database, and networking
   management.<br/>
-  These offers can also be a relevant alternative to host your Taipy applications and
+  These offers can also be relevant to host your Taipy applications and
   provide them to external users.
 
 ## [Running a Taipy application](run/index.md)

--- a/docs/tutorials/fundamentals/3_complete_application/index.md
+++ b/docs/tutorials/fundamentals/3_complete_application/index.md
@@ -45,7 +45,7 @@ $ pip install statsmodels
     `pip install taipy` is the preferred method to install the latest stable version of Taipy.
 
     If you don't have [pip](https://pip.pypa.io) installed, this
-    [Taipy installation guide](../../../installation/index.md)
+    [Taipy installation guide](../../../installation.md)
     can guide you through the process.
 
 

--- a/docs/tutorials/fundamentals/4_chatbot/index.md
+++ b/docs/tutorials/fundamentals/4_chatbot/index.md
@@ -235,10 +235,9 @@ We can add notifications, a sidebar with a button to clear the conversation
 and a history of previous conversations. You can find the full code
 in the [GitHub repository](https://github.com/Avaiga/demo-llm-chat)
 
-# Step 10: Deploying the application to Taipy Cloud
+# Step 10: Secure your API key using an environment variable
 
-We are now going to deploy the application to Taipy Cloud so it is
-accessible from anyone with a link.
+We now want to deploy the application, so it is accessible from anyone with a link.
 
 Firstly we need to store the API key in an environment variable.
 Replace the line that defines *client* in [Step 5](#step-5-create-a-function-to-generate-responses) with:
@@ -251,20 +250,5 @@ client = openai.Client(api_key = os.environ["OPENAI_API_KEY"])
 Now, instead of having our API key in the code, the app will look
 for it in the environment variables.
 
-We can now deploy the app to Taipy Cloud:
+We can now securely deploy the app.
 
-1. Connect to [Taipy Cloud](https://cloud.taipy.io/) and sign in
-2. Click on "Add Machine" and fill in the fields
-3. Select the created machine and click on "Add app"
-4. Zip the `main.py`, `main.css` and `requirements.txt` files and upload the zip file to the "App files" field. Fill in the other fields
-5. In the "Environment Variables" tab, create a new environment variable called `OPENAI_API_KEY` and paste your API key as the value like in the image below
-6. Press "Deploy app"
-
-![Environment Variables Tab](images/chatbot_env_var.png){width=90% : .tp-image-border }
-
-After a while, your app should be running and will be accessible
-from the displayed link!
-
-![Taipy Cloud Interface](images/chatbot_cloud.png){width=90% : .tp-image-border }
-
-![The final application](images/chatbot_roundconv.png){width=90% : .tp-image-border }

--- a/docs/tutorials/integration/index.md_template
+++ b/docs/tutorials/integration/index.md_template
@@ -31,12 +31,6 @@ Explore integration with Taipy and other platforms and libraries.
       <span>Stylekit</span>
     </label>
   </li>
-  <li>
-    <input type="checkbox" name="filter-cloud" id="filter-cloud" value="cloud">
-    <label class="tp-pill" for="filter-cloud">
-      <span>Taipy Cloud</span>
-    </label>
-  </li>
 </ul>
 
 [LIST_OF_ITEMS]

--- a/docs/tutorials/large_data/index.md_template
+++ b/docs/tutorials/large_data/index.md_template
@@ -31,12 +31,6 @@ Learn to manage and manipulate large datasets.
       <span>Stylekit</span>
     </label>
   </li>
-  <li>
-    <input type="checkbox" name="filter-cloud" id="filter-cloud" value="cloud">
-    <label class="tp-pill" for="filter-cloud">
-      <span>Taipy Cloud</span>
-    </label>
-  </li>
 </ul>
 
 [LIST_OF_ITEMS]

--- a/docs/tutorials/scenario_management/index.md_template
+++ b/docs/tutorials/scenario_management/index.md_template
@@ -30,13 +30,6 @@ Uncover strategies for effective scenario and data management.
     <label class="tp-pill" for="filter-stylekit">
       <span>Stylekit</span>
     </label>
-  </li>
-  <li>
-    <input type="checkbox" name="filter-cloud" id="filter-cloud" value="cloud">
-    <label class="tp-pill" for="filter-cloud">
-      <span>Taipy Cloud</span>
-    </label>
-  </li>
 </ul>
 
 [LIST_OF_ITEMS]

--- a/docs/tutorials/visuals/index.md_template
+++ b/docs/tutorials/visuals/index.md_template
@@ -31,12 +31,6 @@ Discover how to enhance your Taipy applications with visuals.
       <span>Stylekit</span>
     </label>
   </li>
-  <li>
-    <input type="checkbox" name="filter-cloud" id="filter-cloud" value="cloud">
-    <label class="tp-pill" for="filter-cloud">
-      <span>Taipy Cloud</span>
-    </label>
-  </li>
 </ul>
 
 [LIST_OF_ITEMS]

--- a/mkdocs.yml_template
+++ b/mkdocs.yml_template
@@ -150,8 +150,6 @@ nav:
               - "Deploying a Taipy application": manuals/run-deploy/deploy/index.md
               - "On the local machine":
                   - "Deploying locally": manuals/run-deploy/deploy/local/index.md
-              - "On Taipy Cloud":
-                  - "Deploying on Taipy Cloud": manuals/run-deploy/deploy/taipy-cloud/index.md
               - "On Linux servers":
                   - "Deploying on a Linux system": manuals/run-deploy/deploy/linux/index.md
                   - "Ubuntu": manuals/run-deploy/deploy/linux/ubuntu.md


### PR DESCRIPTION
- Align the doc Pipfile with the taipy Pipfile @FabienLelaquais this is for you.
- Rename/move `installation/index.md` to `installation.md` to match the same organization as the other single pages not in the nav bar. 
- Remove all Taipy Cloud references.

Please review it quickly so I can propagate the changes to past versions.