### PR TITLE
Fix/#895 - The ellipsis should link to manuals/usermans/

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -141,7 +141,7 @@ from initial prototypes to production-ready applications.
     </a>
   </li>
     <li>
-    <a class="tp-pill" href="manuals/about/">
+    <a class="tp-pill" href="manuals/usermans/">
       <span>…</span>
       <div class="tp-tooltip">
         <p>Browse the complete list of features.</p>


### PR DESCRIPTION
Resolves #895

The ellipsis now would link to https://docs.taipy.io/en/latest/manuals/usermans/

We can also consider linking to https://docs.taipy.io/en/latest/manuals/, which shows both User Manual and Reference Manual. Let me know what you think @FabienLelaquais @jrobinAV 