### PR TITLE
Hotfix3.0/#895 - The ellipsis should link to manuals/usermans/

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -149,7 +149,7 @@ from initial prototypes to production-ready applications.
     </a>
   </li>
     <li>
-    <a class="tp-pill" href="manuals/about/">
+    <a class="tp-pill" href="manuals/usermans/">
       <span>…</span>
       <div class="tp-tooltip">
         <p>Browse the complete list of features.</p>


### PR DESCRIPTION
Resolves #895 

Backport for release 3.0