### PR TITLE
Centered the video elements with tp-video class.

### DIFF
--- a/docs/tutorials/fundamentals/2_scenario_management_overview/index.md
+++ b/docs/tutorials/fundamentals/2_scenario_management_overview/index.md
@@ -121,7 +121,7 @@ Three Data Nodes are being configured (**historical_temperature**, **date_to_for
         Taipy Studio. In fact, Taipy Studio is an editor of a TOML file specific to Taipy. It
         lets you edit and view a TOML file that will be used in our code.
 
-        <video controls width="400">
+        <video controls width="400" class="tp-video" >
             <source src="./images/config.mp4" type="video/mp4">
         </video>
 

--- a/docs/tutorials/scenario_management/2_the_data_nodes/index.md
+++ b/docs/tutorials/scenario_management/2_the_data_nodes/index.md
@@ -47,7 +47,7 @@ two Pickle data nodes: one for getting data in and one for sending data out.
 - *predictions* is an output data node, but right now, it doesn't have any data in it.
   We haven't told it where to get data from yet.
 
-<video width="640" height="360" controls>
+<video width="640" height="360" controls class="tp-video">
   <source src="images/pickle-data-node.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
@@ -107,7 +107,7 @@ The predefined tabular data nodes in Taipy include:
 
 These data nodes allow you to work with tabular data from different sources with ease.
 
-<video width="640" height="360" controls>
+<video width="640" height="360" controls class="tp-video">
   <source src="images/tabular-data-nodes.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
@@ -139,7 +139,7 @@ When you submit the scenario described above for execution in Taipy, the followi
 Here, we'll demonstrate how you can change the exposed type from the default Pandas DataFrame
 to other types, such as *Numpy arrays*:
 
-<video width="640" height="360" controls>
+<video width="640" height="360" controls class="tp-video">
   <source src="images/tabular-data-nodes_2.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>

--- a/docs/tutorials/scenario_management/3_skippable_tasks/index.md
+++ b/docs/tutorials/scenario_management/3_skippable_tasks/index.md
@@ -50,7 +50,7 @@ The order in which you supply Data nodes to the Task is critical.
 Taipy calls the function using the parameters in the same order as the Data nodes,
 and the results are returned in that exact order.
 
-<video width="640" height="360" controls>
+<video width="640" height="360" controls class="tp-video">
   <source src="images/setting_up_nodes_for_tasks.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
@@ -92,7 +92,7 @@ by preventing unnecessary computations, which saves time and resources.
 
 Let’s take the previous execution graph and set *skippable=True* to our Task.
 
-<video width="640" height="360" controls>
+<video width="640" height="360" controls class="tp-video">
   <source src="images/use_case.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>
@@ -162,7 +162,7 @@ skipped across different scenarios.
 
 Let's revisit our previous code and modify the Data nodes to have a Global scope.
 
-<video width="640" height="360" controls>
+<video width="640" height="360" controls class="tp-video">
   <source src="images/using_global_data_nodes.mp4" type="video/mp4">
   Your browser does not support the video tag.
 </video>

--- a/taipy_theme/assets/stylesheets/avaiga.css
+++ b/taipy_theme/assets/stylesheets/avaiga.css
@@ -922,6 +922,14 @@ a.md-content__button{
   display:block;
 }
 
+/* ---------- ---------- ---------- VIDEOS ---------- ---------- ---------- */
+
+.tp-video {
+  margin: auto;
+  display: block;
+}
+
+
 /* ---------- ---------- ---------- Breadcrumbs ---------- ---------- ---------- */
 .tp-bc {
   margin-left: 0.8rem;

--- a/taipy_theme/assets/stylesheets/avaiga.css
+++ b/taipy_theme/assets/stylesheets/avaiga.css
@@ -929,7 +929,6 @@ a.md-content__button{
   display: block;
 }
 
-
 /* ---------- ---------- ---------- Breadcrumbs ---------- ---------- ---------- */
 .tp-bc {
   margin-left: 0.8rem;


### PR DESCRIPTION
## Related Issues
Fixes #616 
## Updates 
- Added "tp-video" class to all the video elements 
- Added `margin: auto; display: block` to the "tp-video". 
## Screenshot
![Screenshot from 2024-05-08 10-17-32](https://github.com/Avaiga/taipy-doc/assets/73622805/07e647c0-a976-4416-a0a5-706f0e763be4)
