### PR TITLE
Fix/#953 - Remove explicit index.md link in href

### DIFF
--- a/docs/manuals/usermans/index.md
+++ b/docs/manuals/usermans/index.md
@@ -16,7 +16,7 @@ These topics are the most visited ones, we thought you’d like to have a glance
 
 <div class="tp-row tp-row--gutter-sm">
   <div class="tp-col-12 tp-col-md-6 d-flex">
-    <a class="tp-content-card tp-content-card--beta" href="../gui/viselements/index.md">
+    <a class="tp-content-card tp-content-card--beta" href="../gui/viselements/">
       <header class="tp-content-card-header">
         <img class="tp-content-card-icon" src="../../images/icons/visual-element-w.svg">
         <h3>Visual elements</h3>


### PR DESCRIPTION
Resolves #953 

The link in href should not have the explicit `index.md` link, just the reference to the link.