### PR TITLE
Disable TOC from the page without title and headings

### DIFF
--- a/docs/manuals/auth/index.md
+++ b/docs/manuals/auth/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 !!! warning "Available in Taipy Enterprise edition"
 
     This chapter is relevant only to the Enterprise edition of Taipy.

--- a/docs/manuals/core/concepts/cycle.md
+++ b/docs/manuals/core/concepts/cycle.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 Data applications are often used to solve business problems that operate periodically (i.e. in time cycles).
 
 Examples:

--- a/docs/manuals/core/concepts/data-node.md
+++ b/docs/manuals/core/concepts/data-node.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 A data node is one of the most important concepts in Taipy Core. It does not contain the data itself but holds all
 the necessary information to read and write the actual data. It can be seen as a dataset descriptor or data reference.
 

--- a/docs/manuals/core/concepts/index.md
+++ b/docs/manuals/core/concepts/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 Taipy Core is an application builder designed to help Python developers turn their data algorithms
 into an interactive production-ready data-driven application. Taipy Core provides the necessary
 concepts for modeling, executing, and monitoring algorithms. The main Taipy concept to model an

--- a/docs/manuals/core/concepts/job.md
+++ b/docs/manuals/core/concepts/job.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 Tasks, Sequences, and Scenarios entities can be submitted for execution. The submission of a scenario triggers the
 submission of all the contained tasks. Similarly, the submission of a sequence also triggers the execution of
 all the ordered tasks.

--- a/docs/manuals/core/concepts/scope.md
+++ b/docs/manuals/core/concepts/scope.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 The `Scope^` of a data node is an enum among the following values :
 
 - `Scope.SCENARIO` (Default value)

--- a/docs/manuals/core/concepts/sequence.md
+++ b/docs/manuals/core/concepts/sequence.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 A `Sequence^` is designed to model an algorithm. It represents a direct acyclic graph of input, intermediate, and output
 data nodes linked together by tasks. A *sequence* is a set of tasks designed to perform functions.
 

--- a/docs/manuals/core/concepts/task.md
+++ b/docs/manuals/core/concepts/task.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 A `Task^` is a runnable Python function provided by the developer. It represents one of the
 steps that the developer wants to implement in her sequence.
 

--- a/docs/manuals/core/config/config-checker.md
+++ b/docs/manuals/core/config/config-checker.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 Taipy provides a checking mechanism to validate if your configuration is correct.
 
 You can trigger the check by calling:

--- a/docs/manuals/core/config/config.md
+++ b/docs/manuals/core/config/config.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 The `Config^` class is a singleton as the entry point for the Taipy Core configuration. It is accessible
 using the following import:
 

--- a/docs/manuals/core/config/task-config.md
+++ b/docs/manuals/core/config/task-config.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 A task configuration is necessary to instantiate a [Task](../concepts/task.md). To create a
 `TaskConfig^`, you can use the `Config.configure_task()^` method with the following parameters:
 

--- a/docs/manuals/core/index.md
+++ b/docs/manuals/core/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 The Taipy Core package is a Python library designed to build powerful and customized data-driven
 back-end applications. It provides the necessary tools to help Python developers transform their
 algorithms into a complete back-end application. It brings algorithm management to another level:

--- a/docs/manuals/gui/notifications.md
+++ b/docs/manuals/gui/notifications.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 Taipy provides a way to inform users that some action is taking place
 as an informative message that does not impact the user interaction.
 

--- a/docs/manuals/index.md
+++ b/docs/manuals/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 The Taipy manuals are split into two categories:
 
 - [**User Manuals**](usermans/index.md): these manuals provide information on how to use different

--- a/docs/manuals/studio/config/files.md
+++ b/docs/manuals/studio/config/files.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 The **Config Files** section holds the list of configuration files (`*.toml`) in your
 project. You will select the one you want to edit from that list.<br/>
 This list shows the base names of all the configuration files. If two configuration files


### PR DESCRIPTION
## Related Issue 
fixed #897 

## Updates 
- Disabled table of contents from the pages without titles and headings with `hide: -toc` so that the page can use the full width.

## Screenshot 
![Screenshot from 2024-05-31 07-59-52](https://github.com/Avaiga/taipy-doc/assets/73622805/eb271d4b-509e-41ac-b27d-cd180d0515fe)
