### PR TITLE
Fix - Update permissions for manage_stale_issues_prs action

### DIFF
--- a/.github/workflows/manage-stale-issue-pr.yml
+++ b/.github/workflows/manage-stale-issue-pr.yml
@@ -4,11 +4,15 @@ on:
   schedule:
     # Run once every day at 9 AM UTC
     - cron: 00 9 * * *
+  workflow_dispatch:
 
 jobs:
   stale-issues-and-prs:
     name: Comment on possible stable issues and PRs, and close stale PRs
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:
@@ -30,6 +34,8 @@ jobs:
   unassign-issues-labeled-waiting-for-contributor-after-14-days-of-inactivity:
     name: Unassign issues labeled \"🥶Waiting for contributor\" after 14 days of inactivity.
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: boundfoxstudios/action-unassign-contributor-after-days-of-inactivity@v1
         with:


### PR DESCRIPTION
We get a new error that is similar to the error on coverage, where the `GITHUB_TOKEN` doesn't have the permission to comment on issues or PRs.

I can not test this yet since it's a schedule job