### PR TITLE
Fix breadcrumbs generation for charts

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -32,6 +32,7 @@ opentelemetry-sdk = ">=1.20.0"
 pandas = "==1.3.5"
 pika = "==1.3.2"
 pika-stubs = "==0.1.3"
+polars = "1.2.1"
 pyarrow = "==14.0.2"
 pymongo = {extras = ["srv"], version = "==4.6.3"}
 python-dotenv = "==1.0.0"
@@ -46,6 +47,8 @@ toml = "==0.10"
 twisted = "==23.8.0"
 tzlocal = "==3.0"
 watchdog = "==4.0.0"
+xlsx2csv = "0.8.2"
+xlsxwriter = "3.2.0"
 
 [dev-packages]
 black = "*"

--- a/tools/postprocess.py
+++ b/tools/postprocess.py
@@ -387,7 +387,7 @@ def on_post_build(env):
                     # Processing for visual element pages:
                     # - Remove <tt> from title
                     # - Add breadcrumbs to Taipy GUI's standard and scenario mgmt element pages
-                    fn_match = re.search(r"(/|\\)gui\1viselements\1(standard-and-blocks|corelements)\1(.*?)\1index.html", filename)
+                    fn_match = re.search(r"(/|\\)gui\1viselements\1(generic|corelements)\1(.*?)\1index.html", filename)
                     element_category = None
                     package = None
                     if fn_match is not None:

--- a/tools/postprocess.py
+++ b/tools/postprocess.py
@@ -386,10 +386,12 @@ def on_post_build(env):
 
                     # Processing for visual element pages:
                     # - Remove <tt> from title
-                    # - Add breadcrumbs to Taipy GUI's control, part and core element pages
-                    fn_match = re.search(r"(/|\\)gui\1(vis|cor)elements\1(.*?)\1index.html", filename)
+                    # - Add breadcrumbs to Taipy GUI's standard and scenario mgmt element pages
+                    fn_match = re.search(r"(/|\\)gui\1viselements\1(standard-and-blocks|corelements)\1(.*?)\1index.html", filename)
                     element_category = None
+                    package = None
                     if fn_match is not None:
+                        package = fn_match[2]
                         if title_match := re.search(r"<title><tt>(.*?)</tt> - Taipy</title>", html_content):
                             html_content = (html_content[:title_match.start()]
                                             + f"<title>{title_match.group(1)} - Taipy</title>"
@@ -404,11 +406,10 @@ def on_post_build(env):
                         ARTICLE_RE = re.compile(r"(<div\s+class=\"md-content\".*?>)(\s*<article)")
                         if article_match := ARTICLE_RE.search(html_content):
                             repl = "\n<ul class=\"tp-bc\">"
-                            if "corelements" in filename:
-                                repl += "<li><a href=\"../../../viselements\"><b>Visual Elements</b></a></li>"
-                                repl += ("<li><a "
-                                         "href=\"../../../viselements/#scenario-and-data-management-controls\"><b"
-                                         ">Scenario management controls</b></a></li>")
+                            if package == "corelements":
+                                repl += ("<li><a href=\"../../../viselements\"><b>Visual Elements</b></a></li>"
+                                          "<li><a href=\"../../../viselements/#scenario-and-data-management-controls\">"
+                                          "<b>Scenario management controls</b></a></li>")
                             else:
                                 chart_part = "../" if element_category == "chart" else ""
                                 repl += f"<li><a href=\"{chart_part}../..\"><b>Visual Elements</b></a></li>"
@@ -417,7 +418,7 @@ def on_post_build(env):
                                 else:
                                     repl += f"<li><a href=\"{chart_part}../..#standard-controls\"><b>Standard controls</b></a></li>"
                                     if chart_part:
-                                        repl += f"<li><a href=\"{chart_part}../../chart\"><b>Charts</b></a></li>"
+                                        repl += f"<li><a href=\"{chart_part}../../standard-and-blocks/chart\"><b>Charts</b></a></li>"
                             repl += "</ul>"
                             html_content = (html_content[:article_match.start()]
                                             + article_match.group(1)

--- a/tools/postprocess.py
+++ b/tools/postprocess.py
@@ -418,7 +418,7 @@ def on_post_build(env):
                                 else:
                                     repl += f"<li><a href=\"{chart_part}../..#standard-controls\"><b>Standard controls</b></a></li>"
                                     if chart_part:
-                                        repl += f"<li><a href=\"{chart_part}../../standard-and-blocks/chart\"><b>Charts</b></a></li>"
+                                        repl += f"<li><a href=\"{chart_part}../../generic/chart\"><b>Charts</b></a></li>"
                             repl += "</ul>"
                             html_content = (html_content[:article_match.start()]
                                             + article_match.group(1)


### PR DESCRIPTION
Fixes #1033
after UserMan reorganisation.

Two unsolved problems yet:
- the "Blocks controls" section header is wrong and should backtrack to "Blocks" (or "Block elements")
- the file `docs/manuals/userman/gui/viselements/viselements.md_template` file generates index.md which is confusing and error-prone.
  Should be renamed to `index.md_template`.
