### PR TITLE
updated robots.txt Non latest documentation fixes#1960

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,6 +1,5 @@
 User-agent: *
 Allow: /en/latest/ # Allow all robots to access the latest version of the documentation
-Allow: /en/* # Allow all robots to access the latest version of the documentation
 Disallow: /en/release-*/ # Disallow all other versions except 'latest'
 
 Sitemap: https://docs.taipy.io/sitemap.xml

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Allow: /en/latest/ # Allow all robots to access the latest version of the documentation
-Disallow: /en/*/ # Disallow all other versions except 'latest'
-Disallow: /en/release-3.0/ # Specifically disallow this old version if needed
+Allow: /en/* # Allow all robots to access the latest version of the documentation
+Disallow: /en/release-*/ # Disallow all other versions except 'latest'
 
 Sitemap: https://docs.taipy.io/sitemap.xml

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /en/latest/ # Allow all robots to access the latest version of the documentation
-Disallow: /en/ # Disallow all robots to access the other versions of the documentation
+Disallow: /en/*/ # Disallow all other versions except 'latest'
+Disallow: /en/release-3.0/ # Specifically disallow this old version if needed
 
 Sitemap: https://docs.taipy.io/sitemap.xml


### PR DESCRIPTION
Summary of Changes:

- Updated robots.txt file to ensure that only the latest version of the Taipy documentation is indexed by search engines.
- Allow search engines to index the latest version: /en/latest/
- Disallow search engines from indexing all other versions: /en/*/
- Sitemap reference added: https://docs.taipy.io/sitemap.xml
fixes #1960

Purpose of These Changes:

- Prevent older documentation versions from appearing in search results when users search for Taipy documentation (e.g., currently, the /en/release-3.0/ version is showing instead of the latest).
- Ensure that search engines prioritize the latest version (/en/latest/) of the documentation.

Next Steps (For Maintainers):

- After merging this PR, it would be helpful to resubmit the robots.txt file and the sitemap via Google Search Console to expedite the reindexing process.
- Consider using the URL removal tool in Google Search Console to request removal of outdated versions from search results to further improve the discoverability of the latest documentation.

Testing:

- The changes have been tested locally by inspecting the robots.txt file and verifying the presence of the canonical tags in the HTML headers of older versions.

Please review the changes, and let me know if any adjustments are needed. I’m happy to assist with further improvements!