### PR TITLE
Fix typo in part.md_template (#1187)

### DIFF
--- a/docs/refmans/gui/viselements/generic/part.md_template
+++ b/docs/refmans/gui/viselements/generic/part.md_template
@@ -198,6 +198,7 @@ You can also embed an external web page, setting the [*page*](#p-page) property 
         ...
         tgb.html("p", "Here is the Wikipedia home page:")
         with tgb.part(page="https://www.wikipedia.org/", height="500px")
+        ```
 
 The resulting page will be displayed as this:
 <figure class="tp-center">


### PR DESCRIPTION
Backport of [PR#1187](https://github.com/Avaiga/taipy-doc/pull/1187),

Added missing triple-backticks to the end of a codeblock.

(cherry picked from commit a95aaeebe9c89c6cfc9dceae312ea0baa9d0ff56)