### PR TITLE
Allows float values for gallery article order

### DIFF
--- a/tools/_setup_generation/items/item.py
+++ b/tools/_setup_generation/items/item.py
@@ -18,7 +18,7 @@ class Item:
             self.category = self.header.get("category")
             self.data_keywords = self.header.get("data-keywords")
             self.short_description = self.header.get("short-description")
-            self.order = int(self.header.get("order", 0))
+            self.order = float(self.header.get("order", 0))
             self.img = self.header.get("img")
         self._check_header()
 


### PR DESCRIPTION
Currently, articles in the gallery are sorted according to an integer value in the header of the article:
![image](https://github.com/user-attachments/assets/49985b08-33b1-4641-bf41-e81a326dc852)

Since the values are integers, adding an article between two articles forces contributors to modify the order value of many articles: if I want to place an article at position 6, I must take all articles from position 6 to N and increment their order by 1.

By accepting float values for order, we allow contributors to place an article at position 6 by setting the order at 6.5