### PR TITLE
Feature/Enterprise#232 - Add documentation for running Orchestrator service using a specific Credentials

### DIFF
--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -85,6 +85,11 @@ additional features.
   [Authorize with SystemCredentials](../userman/advanced_features/auth/authorization.md#authorize-with-systemcredentials)
   for more details.
 
+- The `Orchestrator^` service can now be run with a specific `Credentials^` instead of the
+  default `SystemCredentials^`. See the
+  [Run the Orchestrator service with specific Credentials](../userman/advanced_features/auth/authorization.md#run-the-orchestrator-service-with-specific-credentials)
+  for more details.
+
 ## Significant bug fixes
 
 - No bug fix.

--- a/docs/userman/advanced_features/auth/authorization.md
+++ b/docs/userman/advanced_features/auth/authorization.md
@@ -308,10 +308,11 @@ with Authorize(SystemCredentials()):
 
 # Run the Orchestrator service with specific Credentials
 
-Running the Orchestrator service requires authorization with the `TAIPY_EXECUTOR` role.
+Running the Orchestrator service requires authorization with the `TAIPY_EDITOR` role.
 
 You can specify which `Credentials^` will be used to authorize the actions performed by
-running the Orchestrator service.
+running the Orchestrator service (editing the tasks, jobs, submissions, data nodes, and
+data node's data).
 
 ```python
 from taipy.auth import Authorize, login

--- a/docs/userman/advanced_features/auth/authorization.md
+++ b/docs/userman/advanced_features/auth/authorization.md
@@ -280,7 +280,7 @@ with Authorize(credentials):
 
 ## Authorize with SystemCredentials
 
-`SystemCredentials^` are special `Credentials^` that have the TAIPY_ADMIN role.
+`SystemCredentials^` are special `Credentials^` that have the "TAIPY_ADMIN" role.
 
 The `SystemCredentials^` can be used for administrative actions when there is no
 authenticated user. Typical use cases include:
@@ -305,3 +305,26 @@ with Authorize(SystemCredentials()):
     # from the SystemCredentials
     ...
 ```
+
+# Run the Orchestrator service with specific Credentials
+
+Running the Orchestrator service requires authorization with the `TAIPY_EXECUTOR` role.
+
+You can specify which `Credentials^` will be used to authorize the actions performed by
+running the Orchestrator service.
+
+```python
+from taipy.auth import Authorize, login
+from taipy import Orchestrator
+
+# Get a valid Credentials from Authentication
+credentials = login("user1", "pass123")
+
+orchestrator = Orchestrator()
+with Authorize(credentials):
+    orchestrator.run()
+    ...
+```
+
+If not specified, running the Orchestrator service will use the `SystemCredentials^` to authorize
+for the actions needed to start the service.


### PR DESCRIPTION
Documentation for https://github.com/Avaiga/taipy-enterprise/pull/587