### PR TITLE
Prepare release notes for 4.1

### DIFF
--- a/docs/release-notes/4.1/index.md
+++ b/docs/release-notes/4.1/index.md
@@ -11,7 +11,8 @@ This is the list of changes to Taipy version 4.1.
 
 Published on 2025-05.
 
-[`taipy` 4.1](https://pypi.org/project/taipy/4.1.0/) depends on the latest
+`taipy-enterprise` 4.1 depends on the latest
+[`taipy` 4.1](https://pypi.org/project/taipy/4.1.0/) package which depends on the latest
 [`taipy-common` 4.1](https://pypi.org/project/taipy-common/4.1.0/),
 [`taipy-gui` 4.1](https://pypi.org/project/taipy-gui/4.1.0/),
 [`taipy-core` 4.1](https://pypi.org/project/taipy-core/4.1.0/),
@@ -24,34 +25,43 @@ Published on 2025-05.
 
 <h4>New features</h4>
 
-- :octicons-feed-plus-16:{ .plus-icon title="New feature" } TODO: Event Consumer API
-- :octicons-feed-plus-16:{ .plus-icon title="New feature" } TODO: This is another new feature.
-
-<h4>Improvements and changes</h4>
-
-- :octicons-feed-rocket-16:{ .rocket-icon title="Improvement"} TODO: This is another improvement, or a change.
-
-<h4>Significant bug fixes</h4>
-
-- :octicons-bug-24:{ .bug-icon title="Bug fix" } TODO: This is a bug fix.
-- :octicons-bug-24:{ .bug-icon title="Bug fix" } TODO: This is another bug fix.
-- :octicons-bug-24:{ .bug-icon title="Bug fix" } TODO: This is a third bug fix.
-
-<h4>Deprecations</h4>
-
-- :octicons-alert-fill-24:{ .alert-icon title="Deprecation" } TODO: This is a deprecation.
+- :octicons-feed-plus-16:{ .plus-icon title="New feature" } Event management simplification:
+  A new `GuiEventConsumer` class has been introduced to simplify the management of events
+  in Taipy. <br/>
+  See [issue #2306](https://github.com/Avaiga/taipy/issues/2306)
 
 # <strong><code>taipy-gui</code></strong>
 
 ## 4.1.0
 
+<h4>New features</h4>
+
+- :octicons-feed-plus-16:{ .plus-icon title="New feature" } TODO: https://github.com/Avaiga/taipy/issues/2098
+- :octicons-feed-plus-16:{ .plus-icon title="New feature" } TODO: https://github.com/Avaiga/taipy/issues/1401
+
+<h4>Improvements and changes</h4>
+
+- :octicons-feed-rocket-16:{ .rocket-icon title="Improvement"} TODO: https://github.com/Avaiga/taipy/issues/2288
+- :octicons-feed-rocket-16:{ .rocket-icon title="Improvement"} TODO: https://github.com/Avaiga/taipy/issues/2023
+- :octicons-feed-rocket-16:{ .rocket-icon title="Improvement"} TODO: https://github.com/Avaiga/taipy/issues/1834
+- :octicons-feed-rocket-16:{ .rocket-icon title="Improvement"} TODO: https://github.com/Avaiga/taipy/issues/1314
+
 # <strong><code>taipy-core</code></strong>
+
+## 4.1.0
+
+<h4>Significant bug fixes</h4>
+
+- :octicons-bug-24:{ .bug-icon title="Bug fix" } Global data nodes depending
+  on the order of task configs in the scenario config constructor are missing
+  some task IDs in the parent_ids attribute. <br/>
+  See [issue #2597](https://github.com/Avaiga/taipy/issues/2597).
 
 <h4>Deprecations</h4>
 
-- :octicons-feed-rocket-16:{ .rocket-icon title="Improvement"} TODO: CoreEventConsumerBase
-
-## 4.1.0
+- :octicons-feed-rocket-16:{ .rocket-icon title="Improvement"} Class
+  `CoreEventConsumerBase` has been deprecated in favor of the new API
+  `GuiEventConsumer`.
 
 # <strong><code>taipy-enterprise</code></strong>
 
@@ -59,5 +69,14 @@ Published on 2025-05.
 
 <h4>New features</h4>
 
-- :octicons-feed-plus-16:{ .plus-icon title="New feature" } TODO: Automatic graph Migration
-
+- :octicons-feed-plus-16:{ .plus-icon title="New feature" } A predefined migration function
+  has been added to help upgrading to a new production version. This function is designed
+  to automatically migrate entities based on changes in the scenario configuration graph
+  topology. This includes adding, moving or removing task configurations and/or data node
+  configurations from a scenario configuration graph. <br/>
+  Note that renaming task or data node configurations is considered as a deletion and an addition.
+  Resulting entities won't keep their IDs or previous attributes. <br/>
+  Note that changes in configuration attributes are not automatically migrated. Please refer to
+  the
+  [Migration](../../userman/advanced_features/versioning/production_mode.md#production-version-with-migration-functions)
+  functions for more details. <br/>

--- a/docs/userman/scenario_features/events/index.md
+++ b/docs/userman/scenario_features/events/index.md
@@ -40,7 +40,7 @@ For more details, see the [registration](understanding-notifier-register.md) pag
 
 To process events, follow these steps:
 
-1. Create a new consumer class and extend it from `CoreEventConsumerBase^`.
+1. Create a new consumer class and extend it from `CoreEventConsumerBase`.
 2. Implement the `process_event` method to define your specific event-handling behavior.
 3. Register the consumer using the `Notifier.register()^` method to obtain
 a `registration_id` and a `registered_queue`. These values are used to instantiate a consumer

--- a/mkdocs.yml_template
+++ b/mkdocs.yml_template
@@ -1,5 +1,5 @@
 site_name: Taipy
-site_url: https://docs.taipy.io/en/release-4.0
+site_url: https://docs.taipy.io/en/release-4.1
 site_description: Documentation for Taipy
 site_author: taipy.io
 repo_url: https://github.com/avaiga/taipy

--- a/tools/fetch_source_files.py
+++ b/tools/fetch_source_files.py
@@ -23,7 +23,7 @@ PRIVATE_REPOS = ["enterprise", "designer"]
 OPTIONAL_PACKAGES = {"gui": ["pyarrow", "pyngrok", "python-magic", "python-magic-bin"]}
 
 # Ecosystem offering may have a different version than the main Taipy version
-VERSION_MAP = {"designer": {"4.0": "1.2"}}
+VERSION_MAP = {"designer": {"4.1": "1.2", "4.0": "1.2"}}
 
 args = CLI(os.path.basename(__file__), REPOS).get_args()
 


### PR DESCRIPTION
Prepare release notes for taipy, core and enterprise packages.
Must be updated with actual links later when refman is ready.