### PR TITLE
Use the same parameters names for all on_change callbacks across the documentation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,6 +1,12 @@
 # Installation
 
-To see the changes you make to the documentation in a web browser, follow these steps:
+To see the changes you make to the documentation in a web browser, follow these steps.
+
+### Prerequisites
+
+- Python 3.9+ installed and on PATH
+- Git
+- An internet connection
 
 ### 1. Copy locally the source files from the Taipy repositories
 
@@ -9,12 +15,15 @@ In a terminal at the root of this repository, run:
 python tools/fetch_source_files.py develop
 ```
 
+Note: this script requires network access.
+
 ### 2. Generate the documentation from the source files
+
+The generation of the documentation requires that you use the Pipenv virtualenv management tool.
 
 ```bash
 pip install pipenv
 pipenv install --dev
-pipenv shell
 pipenv run python tools/setup_generation.py
 ```
 
@@ -24,4 +33,5 @@ pipenv run python tools/setup_generation.py
 pipenv run mkdocs serve
 ```
 
-This will launch a web server with the local documentation. Everytime you save a file, the server will automatically relaunch the web server so you can see your changes.
+This will launch a web server (default http://127.0.0.1:8000) with the local documentation. The
+server automatically reloads when you save files. Stop it with Ctrl+C.

--- a/docs/refmans/gui/viselements/generic/charts/advanced.md_template
+++ b/docs/refmans/gui/viselements/generic/charts/advanced.md_template
@@ -442,9 +442,9 @@ selected_indices = []
 
 mean_value = 0.
 
-def on_change(state, var, val):
-    if var == "selected_indices":
-        state.mean_value = numpy.mean([data["y"][idx] for idx in val]) if len(val) else 0
+def on_change(state, var_name, var_value):
+    if var_name == "selected_indices":
+        state.mean_value = numpy.mean([data["y"][idx] for idx in var_value]) if len(var_value) else 0
 ```
 
 The part you should be looking at is the use of the default callback property

--- a/docs/refmans/gui/viselements/generic/date_range.md_template
+++ b/docs/refmans/gui/viselements/generic/date_range.md_template
@@ -52,8 +52,8 @@ The date range selector looks like this:
 
 An `on_change` callback can be set to retrieve the user's selection:
 ```python
-def on_change(s: State, name: str, value: any):
-    if name == "dates":
+def on_change(state: State, var_name: str, var_value: any):
+    if var_name == "dates":
         # value[0] is set to the first selected date
         # value[1] is set to the second selected date
 ```

--- a/docs/tutorials/articles/multi_user/index.md
+++ b/docs/tutorials/articles/multi_user/index.md
@@ -85,7 +85,7 @@ def send_message(state):
     state.current_message = ""
 
 
-def on_change(state, var_name, value):
+def on_change(state, var_name, var_value):
     if var_name == "new_message":
         # Check if the last row is not already the user's message
         if (

--- a/docs/tutorials/articles/multi_user/src/main.py
+++ b/docs/tutorials/articles/multi_user/src/main.py
@@ -18,7 +18,7 @@ def send_message(state):
     state.current_message = ""
 
 
-def on_change(state, var_name, value):
+def on_change(state, var_name, var_value):
     if var_name == "new_message":
         # Check if the last row is not already the user's message
         if (
@@ -28,9 +28,7 @@ def on_change(state, var_name, value):
             state.conversation = pd.concat(
                 [
                     state.conversation,
-                    pd.DataFrame(
-                        {"User": [state.user_name], "Message": [state.new_message]}
-                    ),
+                    pd.DataFrame({"User": [state.user_name], "Message": [state.new_message]}),
                 ],
                 ignore_index=True,
             )
@@ -42,9 +40,7 @@ if __name__ == "__main__":
 
     client_index = 1
     user_name = ""
-    conversation = pd.DataFrame(
-        {"User": ["Alex", "Doppler"], "Message": ["Hey!", "Whats'up?"]}
-    )
+    conversation = pd.DataFrame({"User": ["Alex", "Doppler"], "Message": ["Hey!", "Whats'up?"]})
     current_message = ""
     new_message = ""
     new_sender = ""

--- a/docs/tutorials/articles/multi_user/src/main_tgb.py
+++ b/docs/tutorials/articles/multi_user/src/main_tgb.py
@@ -19,7 +19,7 @@ def send_message(state):
     state.current_message = ""
 
 
-def on_change(state, var_name, value):
+def on_change(state, var_name, var_value):
     if var_name == "new_message":
         # Check if the last row is not already the user's message
         if (
@@ -29,9 +29,7 @@ def on_change(state, var_name, value):
             state.conversation = pd.concat(
                 [
                     state.conversation,
-                    pd.DataFrame(
-                        {"User": [state.user_name], "Message": [state.new_message]}
-                    ),
+                    pd.DataFrame({"User": [state.user_name], "Message": [state.new_message]}),
                 ],
                 ignore_index=True,
             )
@@ -43,9 +41,7 @@ if __name__ == "__main__":
 
     client_index = 1
     user_name = ""
-    conversation = pd.DataFrame(
-        {"User": ["Alex", "Doppler"], "Message": ["Hey!", "Whats'up?"]}
-    )
+    conversation = pd.DataFrame({"User": ["Alex", "Doppler"], "Message": ["Hey!", "Whats'up?"]})
     current_message = ""
     new_message = ""
     new_sender = ""

--- a/docs/userman/gui/callbacks.md
+++ b/docs/userman/gui/callbacks.md
@@ -5,7 +5,7 @@ web browser requires that the application handles.
 Every callback function receives a `State^` object as its first parameter.<br/>
 This object reflects the state of the application variables, for a given end-user:
 your application may be used simultaneously by different users connected to the
-same web server (note that setting the _single_client_ configuration parameter to
+same web server (note that setting the *single_client* configuration parameter to
 True - as explained in the
 [Configuration](../advanced_features/configuration/gui-config.md#configuring-the-gui-instance) section - prevents
 multiple users from connecting to your application simultaneously, but you still rely
@@ -20,7 +20,7 @@ for reading and writing.
 Some controls (such as [`input`](../../refmans/gui/viselements/generic/input.md) or
 [`slider`](../../refmans/gui/viselements/generic/slider.md))
 let the user modify the value they hold.
-In order to control what that _new value_ is and decide whether to use
+In order to control what that *new value* is and decide whether to use
 it as such, a callback function is called in the application when the user
 activates the control in order to change its value.
 
@@ -29,9 +29,9 @@ activates the control in order to change its value.
     ```py
     from taipy.gui import Gui
 
-    def on_change(state, var, val):
-        if var == "x":
-            print(f"'x' was changed to: {val}")
+    def on_change(state, var_name, var_value):
+        if var_name == "x":
+            print(f"'x' was changed to: {var_value}")
 
     if __name__ == "__main__":
         md = """
@@ -56,14 +56,14 @@ In our example, that would be `state.x`.
 
 !!! note "Control-specific on_change callback"
     All the controls that allow users to impact the variables they rely on let
-    you specify a specific _on_change_ callback. This is done using the
-    _on_change_ property of each control.<br/>
+    you specify a specific `on_change` callback. This is done using the
+    *on_change* property of each control.<br/>
     That makes it easier to organize your application code in situations where
-    there are many controls to handle, where a single _on_change_ function would
+    there are many controls to handle, where a single *on_change()* function would
     become very large.
 
-    In the code above, you could isolate the _on_change_ function for the slider
-    control using its _on_change_ property:
+    In the code above, you could isolate the *on_change()* function for the slider
+    control using its *on_change* property:
     ```py
     ...
     md = """
@@ -80,8 +80,8 @@ In our example, that would be `state.x`.
     ...
     ```
     You would not have to check the variable name anymore (although the callback function
-    still receives it) since you know that _on_slider_change_, in this case, will be
-    invoked _only_ when the user interacts with the slider.
+    still receives it) since you know that *on_slider_change()*, in this case, will be
+    invoked *only* when the user interacts with the slider.
 
 # Actions
 
@@ -222,7 +222,7 @@ parameter to `invoke_long_callback()^`) have passed since *heavy_function()* was
 
 # Long-running callbacks in a Thread
 
-The execution of long-running callback using `invoke_long_callback()` may however not apply to
+The execution of long-running callback using `invoke_long_callback()^` may however not apply to
 a specific situation. This API hides many technical details that some application may want to
 be more in control of.
 

--- a/docs/userman/gui/styling/index.md
+++ b/docs/userman/gui/styling/index.md
@@ -37,7 +37,7 @@ There are two ways you can apply a stylesheet to your application:
     The parameter to the *style* parameter is a dictionary where keys describe the CSS selector to
     apply, and the value is the rule declaration, expressed as a dictionary (each key being the
     CSS property name and each value being the property value).<br/>
-    Here is an example of defining CSS styling on a page:
+    Consider the following page definition:
     === "Python"
         ```python
         with tgb.Page(style = {
@@ -54,7 +54,16 @@ There are two ways you can apply a stylesheet to your application:
                           ".taipy-button": {
                             "background-color": "red"
                           }
-                        }
+                        )
+        ```
+    === "HTML"
+        ```python
+        page = Html("... page content",
+                    style = {
+                      ".taipy-button": {
+                        "background-color": "red"
+                      }
+                    )
         ```
     This style creates a single CSS rule that will apply to all `button` controls of this page,
     giving them a red background color.
@@ -67,9 +76,10 @@ There are two ways you can apply a stylesheet to your application:
         with tgb.Page(style = {
                         ".taipy-slider": {
                           ".MuiSlider-rail": {
-                          "background-color": "yellow"
+                            "background-color": "yellow"
+                          }
                         }
-                      }) as page:
+                      ) as page:
             # page content
         ```
     === "Markdown"
@@ -79,8 +89,20 @@ There are two ways you can apply a stylesheet to your application:
                           ".taipy-slider": {
                             ".MuiSlider-rail": {
                               "background-color": "yellow"
+                            }
                           }
+                        )
+        ```
+    === "HTML"
+        ```python
+        page = Html("... page content",
+                    style = {
+                      ".taipy-slider": {
+                        ".MuiSlider-rail": {
+                          "background-color": "yellow"
                         }
+                      }
+                    )
         ```
     This style definition will apply the yellow color to the rail of a `slider` control. It does
     this by selecting all the elements with the ".MuiSlider-rail" class that are a descendants

--- a/mkdocs.yml_template
+++ b/mkdocs.yml_template
@@ -412,7 +412,7 @@ plugins:
         python:
           options:
             show_source: false
-            parameter_headings: true
+            parameter_headings: false
             merge_init_into_class: false
             show_root_toc_entry: false
             show_root_full_path: false


### PR DESCRIPTION
- on_change signature homogeneity
- fix parameter names appearing in the RefMan pages TOC section.