### PR TITLE
doc/#2783-document-editable-and-editing-suffixes-for-cell-class-name

### DIFF
--- a/docs/refmans/gui/viselements/generic/table.md_template
+++ b/docs/refmans/gui/viselements/generic/table.md_template
@@ -1337,28 +1337,29 @@ The [example](#styling-rows) below shows how this works.
 
 !!! note "Editable tables and CSS class suffixes"
 
-    When the `editable` option is enabled on a table, Taipy automatically
-    appends a suffix to the CSS class returned by
-    `cell_class_name[column_name]`:
+    When the [*editable*](#p-editable) property is set to True, Taipy
+    automatically appends a suffix to the CSS class returned by
+    [*cell_class_name[column_name]*](#p-cell_class_name[column_name]):
 
     - `-editable` when the cell is editable
     - `-editing` when the cell is actively being edited
 
-    For example, if `cell_class_name[column_name]` returns `pink-cell`,
-    the applied class may be `pink-cell-editable` or
-    `pink-cell-editing`.
+    For example, if
+    [*cell_class_name[column_name]*](#p-cell_class_name[column_name])
+    returns "pink-cell", the applied class will be
+    "pink-cell-editable" or "pink-cell-editing", when the table content
+    can be edited.
 
-    To ensure consistent styling, define CSS rules for all variants.
+    To maintain consistent styling, ensure that CSS rules are defined
+    for all variants.
 
-```html
-<style>
-.pink-cell,
-.pink-cell-editable,
-.pink-cell-editing {
-  background-color: #ffd6e5;
-}
-</style>
-```
+    ```css
+    .pink-cell,
+    .pink-cell-editable,
+    .pink-cell-editing {
+      background-color: #ffd6e5;
+    }
+    ```
 
 ### Styling rows {data-source="gui:doc/examples/controls/table_styling_rows/"}
 

--- a/docs/refmans/gui/viselements/generic/table.md_template
+++ b/docs/refmans/gui/viselements/generic/table.md_template
@@ -1330,9 +1330,35 @@ The signature of this function depends on which property you use:
      - *row*: all the values for this row
      - *column_name*: the name of the column for this cell
 
-Based on these parameters, the function must return a string that defines a CSS class name that will
-be added to the CSS classes for this table row or this specific cell.<br/>
+Based on these parameters, the function must return a string that defines a CSS
+class name that will be added to the CSS classes for this table row or this
+specific cell.<br/>
 The [example](#styling-rows) below shows how this works.
+
+!!! note "Editable tables and CSS class suffixes"
+
+    When the `editable` option is enabled on a table, Taipy automatically
+    appends a suffix to the CSS class returned by
+    `cell_class_name[column_name]`:
+
+    - `-editable` when the cell is editable
+    - `-editing` when the cell is actively being edited
+
+    For example, if `cell_class_name[column_name]` returns `pink-cell`,
+    the applied class may be `pink-cell-editable` or
+    `pink-cell-editing`.
+
+    To ensure consistent styling, define CSS rules for all variants.
+
+```html
+<style>
+.pink-cell,
+.pink-cell-editable,
+.pink-cell-editing {
+  background-color: #ffd6e5;
+}
+</style>
+```
 
 ### Styling rows {data-source="gui:doc/examples/controls/table_styling_rows/"}
 


### PR DESCRIPTION
## Summary

This PR improves the Taipy documentation by clarifying how CSS class names
returned by `cell_class_name[column_name]` behave when the `editable`
option is enabled on a table.

Specifically, it documents the automatic `-editable` and `-editing`
suffixes applied to CSS classes for editable table cells.

## Context

This change follows a user-reported issue where conditional cell styling
appeared to stop working when table editing was enabled.

The behavior was confirmed to be expected, but undocumented, which caused
confusion for users styling editable tables.

## Changes

- Added a documentation note in:
  **Dynamic styling → Styling cells**
- Explained the `-editable` and `-editing` CSS class suffix behavior
- Added a short CSS example demonstrating how to handle all cell states
- Kept formatting, style, and line length consistent with existing docs

## Why this matters

Without this documentation, users may assume that `cell_class_name` does
not work with editable tables, while in reality they must account for
state-specific CSS class suffixes.

This update prevents that confusion and improves developer experience.

## Related issues

- Fixes taipy/taipy#2783
- Follow-up to taipy/taipy#2776
