### PR TITLE
Suppress warning in documentation generation

### DIFF
--- a/tools/_fetch_source_file/utils.py
+++ b/tools/_fetch_source_file/utils.py
@@ -2,17 +2,17 @@ import os
 import re
 
 
-def read_doc_version_from_mkdocs_yml_template_file(root_dir):
+def read_doc_version_from_mkdocs_yml_template_file(root_dir: str) -> str:
     """Read version from mkdocs.yml template"""
     mkdocs_yml_template = None
     mkdocs_yml_template_path = os.path.join(root_dir, "mkdocs.yml_template")
     with open(mkdocs_yml_template_path, "r") as mkdocs_file:
         mkdocs_yml_template = mkdocs_file.read()
-    if mkdocs_yml_template is None:
-        raise IOError(f"Couldn't open '{mkdocs_yml_template_path}'")
-    mkdocs_yml_version = re.search(r"site_url:\s*https://docs\.taipy\.io/en/(develop|release-(\d\.\d))$",
-                                   mkdocs_yml_template, re.MULTILINE)
+    mkdocs_yml_version = re.search(
+        r"site_url:\s*https://docs\.taipy\.io/en/(develop|release-(\d\.\d))$", mkdocs_yml_template, re.MULTILINE
+    )
     if mkdocs_yml_version is None:
         raise ValueError(
-            f"'{mkdocs_yml_template_path}' has an invalid site_url value. This must be 'develop' or 'release-[M].[m]'.")
+            f"'{mkdocs_yml_template_path}' has an invalid site_url value. This must be 'develop' or 'release-[M].[m]'."
+        )
     return mkdocs_yml_version.group(2) if mkdocs_yml_version.group(2) else mkdocs_yml_version.group(1)

--- a/tools/_setup_generation/refman/entry.py
+++ b/tools/_setup_generation/refman/entry.py
@@ -1,4 +1,5 @@
 import os
+import typing as t
 
 
 class Entry:
@@ -6,7 +7,16 @@ class Entry:
     FUNCTION_ID = "F"
     TYPE_ID = "T"
 
-    def __init__(self, name, simple_name, parent_module, entry_type, doc, first_line_doc, packages):
+    def __init__(
+        self,
+        name: str,
+        simple_name: str,
+        parent_module: str,
+        entry_type: str,
+        doc: t.Optional[str],
+        first_line_doc: t.Optional[str],
+        packages: list[str],
+    ):
         self.name = name
         self.simple_name = simple_name
         self.parent_module = parent_module
@@ -22,20 +32,20 @@ class Entry:
 
     @property
     def index_documentation(self):
-        line = self.first_line_doc if self.first_line_doc else ' - NOT DOCUMENTED'
+        line = self.first_line_doc if self.first_line_doc else " - NOT DOCUMENTED"
         return f"- [`{self.simple_name}{self.suffix}`]({self.simple_name}/index.md){': ' + line}\n"
 
     def set_at_root(self) -> None:
         self.at_root = True
 
-    def remove_package(self, package) -> None:
+    def remove_package(self, package: str) -> None:
         if package in self.packages:
             self.packages.remove(package)
 
-    def set_doc_package(self, package) -> None:
+    def set_doc_package(self, package: str) -> None:
         self.doc_package = package
 
-    def generate(self, docs_path, folder_path) -> None:
+    def generate(self, docs_path: str, folder_path: str) -> None:
         self._compute_navigation(folder_path)
         self._write_doc(docs_path, folder_path)
 
@@ -43,78 +53,109 @@ class Entry:
     def _doc_full_name(self):
         return f"{self.doc_package}.{self.simple_name}"
 
-    def _write_doc(self, docs_path, folder_path) -> None:
+    def _write_doc(self, docs_path: str, folder_path: str) -> None:
         os.makedirs(os.path.join(docs_path, folder_path, self.simple_name), exist_ok=True)
         with open(os.path.join(docs_path, folder_path, self.simple_name, "index.md"), "w") as file:
-            file.write("---\n"
-                       f"title: {self.simple_name}{self.suffix} {str(self._get_type_title()).lower()}\n"
-                       "---\n\n"
-                       f"::: {self._doc_full_name}\n")
+            file.write(
+                "---\n"
+                f"title: {self.simple_name}{self.suffix} {str(self._get_type_title()).lower()}\n"
+                "---\n\n"
+                f"::: {self._doc_full_name}\n"
+            )
 
-    def _compute_navigation(self, folder_path) -> None:
+    def _compute_navigation(self, folder_path: str) -> None:
         pass
 
-    def is_function(self):
+    def is_function(self) -> bool:
         return False
 
-    def is_class(self):
+    def is_class(self) -> bool:
         return False
 
-    def is_type(self):
+    def is_type(self) -> bool:
         return False
 
-    def _get_type_title(self):
+    def _get_type_title(self) -> str:
         raise NotImplementedError
 
 
 class FunctionEntry(Entry):
-
-    def __init__(self, name, simple_name, parent_module, doc, first_line_doc, packages):
+    def __init__(
+        self,
+        name: str,
+        simple_name: str,
+        parent_module: str,
+        doc: t.Optional[str],
+        first_line_doc: t.Optional[str],
+        packages: list[str],
+    ):
         super().__init__(name, simple_name, parent_module, self.FUNCTION_ID, doc, first_line_doc, packages)
         self.suffix = "()"
 
-    def is_function(self):
+    def is_function(self) -> bool:
         return True
 
-    def _get_type_title(self):
+    def _get_type_title(self) -> str:
         return "Function"
 
 
 class ClassEntry(Entry):
-
-    def __init__(self, name, simple_name, parent_module, doc, first_line_doc, packages):
+    def __init__(
+        self,
+        name: str,
+        simple_name: str,
+        parent_module: str,
+        doc: t.Optional[str],
+        first_line_doc: t.Optional[str],
+        packages: list[str],
+    ):
         super().__init__(name, simple_name, parent_module, self.CLASS_ID, doc, first_line_doc, packages)
 
-    def is_class(self):
+    def is_class(self) -> bool:
         return True
 
-    def _get_type_title(self):
+    def _get_type_title(self) -> str:
         return "Class"
 
-    def _compute_navigation(self, folder_path) -> None:
+    def _compute_navigation(self, folder_path: str) -> None:
         folders = self._doc_full_name.split(".")
         self.navigation = (len(folders) - 2) * "  " + f'- "<code>{self.simple_name}</code>":\n'
-        self.navigation += ((len(folders)) * "  " +
-                            f'- "{self.simple_name} {str(self._get_type_title()).lower()}": '
-                            f'{folder_path}/{self.simple_name}/index.md\n')
+        self.navigation += (
+            (len(folders)) * "  " + f'- "{self.simple_name} {str(self._get_type_title()).lower()}": '
+            f"{folder_path}/{self.simple_name}/index.md\n"
+        )
 
 
 class TypeEntry(Entry):
-
-    def __init__(self, name, simple_name, parent_module, doc, first_line_doc, packages):
+    def __init__(
+        self,
+        name: str,
+        simple_name: str,
+        parent_module: str,
+        doc: t.Optional[str],
+        first_line_doc: t.Optional[str],
+        packages: list[str],
+    ):
         super().__init__(name, simple_name, parent_module, self.TYPE_ID, doc, first_line_doc, packages)
 
-    def is_type(self):
+    def is_type(self) -> bool:
         return True
 
-    def _get_type_title(self):
+    def _get_type_title(self) -> str:
         return "Type"
 
 
 class EntryBuilder:
-
     @staticmethod
-    def build_entry(name, simple_name, parent_module, entry_type, doc, first_line_doc, packages) -> Entry:
+    def build_entry(
+        name: str,
+        simple_name: str,
+        parent_module: str,
+        entry_type: str,
+        doc: t.Optional[str],
+        first_line_doc: t.Optional[str],
+        packages: list[str],
+    ) -> Entry:
         if entry_type == Entry.CLASS_ID:
             return ClassEntry(name, simple_name, parent_module, doc, first_line_doc, packages)
         elif entry_type == Entry.FUNCTION_ID:

--- a/tools/_setup_generation/refman/reader.py
+++ b/tools/_setup_generation/refman/reader.py
@@ -1,8 +1,10 @@
 import re
 from inspect import isclass, isfunction, ismodule
+from types import ModuleType
 from .entry import Entry, EntryBuilder
 from ..setup import Setup
 from importlib import import_module
+import typing as t
 
 
 class Reader:
@@ -13,15 +15,15 @@ class Reader:
     FIRST_DOC_LINE_RE = re.compile(r"^(.*?)(:?\n\s*\n|$)", re.DOTALL)
     REMOVE_LINE_SKIPS_RE = re.compile(r"\s*\n\s*", re.MULTILINE)
 
-    HIDDEN_ENTRIES = []
-    HIDDEN_ENTRIES_FULL = []
+    HIDDEN_ENTRIES: t.List[str] = []
+    HIDDEN_ENTRIES_FULL: t.List[str] = []
 
     def __init__(self, setup: Setup):
         self.setup = setup
         self.entries: dict[str, Entry] = {}  # All entries from taipy that are not private or hidden
-        self.package_doc = {}  # Documentation for each package
+        self.package_doc: dict[str, t.Optional[str]] = {}  # Documentation for each package
 
-        self.loaded_modules = set()  # All the modules already processed and loaded
+        self.loaded_modules: set[ModuleType] = set()
 
     def read_symbols(self):
         self._read_module(import_module(self.setup.ROOT_PACKAGE))
@@ -29,7 +31,7 @@ class Reader:
         self._read_module(import_module("taipy.event"))
         self._read_module(import_module("taipy.gui.test"))
 
-    def _read_module(self, module):
+    def _read_module(self, module: ModuleType):
         if module in self.loaded_modules:
             return
         self.loaded_modules.add(module)
@@ -45,7 +47,7 @@ class Reader:
                 continue
 
             # Type ?
-            entry_type: str = None
+            entry_type: t.Optional[str] = None
             if hasattr(e, "__module__") and e.__module__:
                 # Handling alias Types
                 if e.__module__.startswith(self.setup.ROOT_PACKAGE):  # For local build

--- a/tools/_setup_generation/step_gui_ext_refman.py
+++ b/tools/_setup_generation/step_gui_ext_refman.py
@@ -30,7 +30,7 @@ class GuiExtRefManStep(SetupStep):
             try:
                 subprocess.run(f"{npm_path} --version", shell=True, capture_output=True)
             except OSError:
-                print(f"WARNING: Couldn't run npm, ignoring this step.", flush=True)
+                print("WARNING: Couldn't run npm, ignoring this step.", flush=True)
                 npm_path = None
         self.npm_path = npm_path
 
@@ -39,9 +39,9 @@ class GuiExtRefManStep(SetupStep):
             saved_cwd = os.getcwd()
             gui_path = os.path.join(setup.root_dir, "taipy-fe")
             os.chdir(gui_path)
-            print(f"... Installing node modules...", flush=True)
+            print("... Installing node modules...", flush=True)
             subprocess.run(f"{self.npm_path} i --omit=optional", shell=True)
-            print(f"... Generating documentation...", flush=True)
+            print("... Generating documentation...", flush=True)
             subprocess.run(f"{self.npm_path} run mkdocs", shell=True)
             # Process and copy files to docs/userman
             os.mkdir(self.GUI_EXT_REF_DIR_PATH)
@@ -56,11 +56,7 @@ class GuiExtRefManStep(SetupStep):
                         file_content = input.read()
                     match = JS_EXT_RE.search(file_content)
                     if match:
-                        file_content = (
-                            match.group(2)
-                            + match.group(1)
-                            + file_content[match.end() :]
-                        )
+                        file_content = match.group(2) + match.group(1) + file_content[match.end() :]
                     path_name = path_name.replace(src_dir, dst_dir)
                     with open(path_name, "w") as output:
                         output.write(file_content)

--- a/tools/fetch_source_files.py
+++ b/tools/fetch_source_files.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import subprocess
+import typing as t
 
 from _fetch_source_file import (
     CLI,
@@ -30,8 +31,16 @@ args = CLI(os.path.basename(__file__), REPOS).get_args()
 # Read version from mkdocs.yml template
 mkdocs_yml_version = read_doc_version_from_mkdocs_yml_template_file(ROOT_DIR)
 
+
 # Gather version information for each repository
-repo_defs = {
+class RepoDefinition(t.TypedDict):
+    version: str
+    tag: t.Optional[str]
+    path: t.NotRequired[t.Optional[str]]
+    skip: t.NotRequired[t.Optional[bool]]
+
+
+repo_defs: dict[str, RepoDefinition] = {
     repo if repo == "taipy" else f"taipy-{repo}": {"version": "local", "tag": None} for repo in REPOS + PRIVATE_REPOS
 }
 CATCH_VERSION_RE = re.compile(r"(^\d+\.\d+?)(?:(\.\d+)(\..*)?)?|develop|local$")
@@ -80,6 +89,7 @@ for repo, version_remap_desc in VERSION_MAP.items():
 
 # Test git, if needed
 git_command = "git"
+git_path = "<undetermined path to git executable>"
 if args.no_pull and all(v["version"] == "local" for v in repo_defs.values()):
     git_command = None
 else:
@@ -175,7 +185,7 @@ os.makedirs(DEST_DIR)
 # If a leftover of a previous failed run
 safe_rmtree(os.path.join(TOOLS_PATH, DEST_DIR_NAME))
 
-pipfile_packages = {}
+pipfile_packages: dict[str, dict[str, list[str]]] = {}
 PIPFILE_PACKAGE_RE = re.compile(r"(..*?)\s?=\s?(.*)")
 
 
@@ -251,13 +261,13 @@ def move_files(repo: str, src_path: str):
         safe_rmtree(dest_dir)
         os.mkdir(dest_dir)
         subprocess.run(
-            f"python \"{os.path.join(tools_src_dir, 'zip_examples.py')}\" "
+            f'python "{os.path.join(tools_src_dir, "zip_examples.py")}" '
             # src_directory
-            f"\"{taipy_docs_src_dir}\" "
+            f'"{taipy_docs_src_dir}" '
             # intermediate_directory
-            f"\"{dest_dir}\" "
+            f'"{dest_dir}" '
             # target_directory
-            f"\"{designer_doc_dir}\" "
+            f'"{designer_doc_dir}" '
             # zip)file
             "examples.zip",
             shell=True,
@@ -269,13 +279,13 @@ def move_files(repo: str, src_path: str):
         safe_rmtree(dest_dir)
         os.mkdir(dest_dir)
         subprocess.run(
-            f"python \"{os.path.join(tools_src_dir, 'zip_examples.py')}\" "
+            f'python "{os.path.join(tools_src_dir, "zip_examples.py")}" '
             # src_directory
-            f"\"{os.path.join(taipy_docs_src_dir, 'training')}\" "
+            f'"{os.path.join(taipy_docs_src_dir, "training")}" '
             # intermediate_directory
-            f"\"{dest_dir}\" "
+            f'"{dest_dir}" '
             # target_directory
-            f"\"{os.path.join(designer_doc_dir, 'training')}\" "
+            f'"{os.path.join(designer_doc_dir, "training")}" '
             # zip)file
             "training.zip",
             shell=True,
@@ -305,7 +315,7 @@ def move_files(repo: str, src_path: str):
                             with open(full_dst, "r") as f:
                                 dst = f.read()
                             if src != dst:
-                                if not item.endswith("config.pyi"): # TODO: Should be improved
+                                if not item.endswith("config.pyi"):  # TODO: Should be improved
                                     raise FileExistsError(
                                         f"File {rel_path}/{item} "
                                         f"already exists and is different (copying repository {repo})"
@@ -375,8 +385,10 @@ for repo in repo_defs.keys():
     version = repo_defs[repo]["version"]
     print(f"Fetching file for repository {repo} ({version})", flush=True)
     if version == "local":
-        src_path = repo_defs[repo]["path"]
-        if not args.no_pull:
+        src_path = repo_defs[repo].get("path", None)
+        if src_path is None:
+            raise ValueError(f"Path for local repository '{repo}' is not defined.")
+        elif not args.no_pull:
             cwd = os.getcwd()
             os.chdir(src_path)
             subprocess.run(f'"{git_path}" pull', shell=True, capture_output=True, text=True)
@@ -410,7 +422,7 @@ for repo in repo_defs.keys():
 
         # For some reason, we need to protect the removal of the clone dirs...
         # See https://stackoverflow.com/questions/1213706/what-user-do-python-scripts-run-as-in-windows
-        def handleRemoveReadonly(func, path, exc):
+        def handleRemoveReadonly(func: t.Any, path: str, exc: t.Any):
             import errno
             import stat
 
@@ -420,6 +432,7 @@ for repo in repo_defs.keys():
             else:
                 raise
 
+        # This was replaced in Python 3.12, but we want to keep compatibility with Python 3.9+
         shutil.rmtree(clone_dir, onerror=handleRemoveReadonly)
 
 if os.path.isdir(os.path.join(ROOT_DIR, "fe_node_modules")) and os.path.isdir(os.path.join(frontend_dir)):
@@ -429,11 +442,22 @@ if os.path.isdir(os.path.join(ROOT_DIR, "fe_node_modules")) and os.path.isdir(os
     )
 
 # Manually add the taipy.run() function.
+# Remove the import from _run to avoid the confusion from griffe
 # TODO: Automate this, grabbing the function from the 'taipy' repository,
 # so we benefit from potential updates.
 init_path = os.path.join(ROOT_DIR, "taipy", "__init__.py")
-with open(init_path, "a") as init:
-    run_method = """
+init_content = ""
+with open(init_path, "r") as init_file:
+    init_content = init_file.read()
+match = re.search(r"\n\s*if find_spec\(\"taipy._run\"\).*?import _run as run\s*?", init_content, re.DOTALL)
+
+with open(init_path, "w") as init:
+    if match:
+        init.write(init_content[: match.start()])
+        init.write(init_content[match.end() :])
+    else:
+        init.write(init_content)
+    run_method_doc = """
 import typing as t
 
 def run(*services: t.Union[Gui, Rest, Orchestrator], **kwargs) -> t.Optional[t.Union[Gui, Rest, Orchestrator]]:
@@ -448,7 +472,7 @@ def run(*services: t.Union[Gui, Rest, Orchestrator], **kwargs) -> t.Optional[t.U
         **kwargs (dict[str, any]): Other parameters to provide to the services.
     \"\"\"
     pass\n"""
-    init.write(run_method)
+    init.write(run_method_doc)
 
 # Generate Pipfile from package dependencies from all repositories
 pipfile_path = os.path.join(ROOT_DIR, "Pipfile")
@@ -469,8 +493,8 @@ if pipfile_path:
         pipfile_lines = pipfile.readlines()
     new_pipfile_path = os.path.join(ROOT_DIR, "Pipfile.new")
     in_packages_section = False
-    legacy_pipfile_packages = {}
-    pipfile_changes = []
+    legacy_pipfile_packages: dict[str, str] = {}
+    pipfile_changes: list[str] = []
     with open(new_pipfile_path, "w") as new_pipfile:
         for line in pipfile_lines:
             if in_packages_section:


### PR DESCRIPTION
When generating the Python API generation, griffe and mkdocs issue warnings that are annoying, confusing, and useless.
